### PR TITLE
Add NuGet links and package names to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,15 @@
 
 Fable bindings for [Browser Web APIs](https://developer.mozilla.org/docs/Web/API)
 
+|NuGet|Name|Description|
+|-----|----|-----------|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Blob.svg)](https://www.nuget.org/packages/Fable.Browser.Blob)|[Fable.Browser.Blob](src/Blob/README.md)|Bindings for the browser Blob API.|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Dom.svg)](https://www.nuget.org/packages/Fable.Browser.Dom)|[Fable.Browser.Dom](src/Dom/README.md)|Bindings for DOM and HTML interfaces|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Event.svg)](https://www.nuget.org/packages/Fable.Browser.Event)|[Fable.Browser.Event](src/Event/README.md)|Bindings for the browser Event interface|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Performance.svg)](https://www.nuget.org/packages/Fable.Browser.Performance)|[Fable.Browser.Performance](src/Performance/README.md)|Bindings for the browser Performance API|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Url.svg)](https://www.nuget.org/packages/Fable.Browser.Url)|[Fable.Browser.Url](src/Url/README.md)|Bindings for the browser Url API|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.WebSocket.svg)](https://www.nuget.org/packages/Fable.Browser.WebSocket)|[Fable.Browser.WebSocket](src/WebSocket/README.md)|Bindings for the browser WebSocket API|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.WebStorage.svg)](https://www.nuget.org/packages/Fable.Browser.WebStorage)|[Fable.Browser.WebStorage](src/WebStorage/README.md)|Bindings for the Web Storage API|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.XMLHttpRequest.svg)](https://www.nuget.org/packages/Fable.Browser.XMLHttpRequest)|[Fable.Browser.XMLHttpRequest](src/XMLHttpRequest/README.md)|Bindings for the browser XMLHttpRequest API|
+
 - Publish: `npm run build Publish`


### PR DESCRIPTION
Easy to copy package names and NuGet links with version directly in the readme

I didn't find this information in an easy accessible place when I searched for it so I added it.