### PR TITLE
Add SVG and CSS bindings

### DIFF
--- a/src/Dom/Browser.Dom.fs
+++ b/src/Dom/Browser.Dom.fs
@@ -48,11 +48,11 @@ type [<AllowNullLiteral>] Document =
     inherit GlobalEventHandlers
     inherit NodeSelector
     inherit DocumentEvent
+    /// Gets the root svg element in the document hierarchy.
+    abstract rootElement: SVGSVGElement with get, set
+    /// Retrieves a collection of styleSheet objects representing the style sheets that correspond to each instance of a link or style object in the document.
+    abstract styleSheets: StyleSheetList with get, set
     // TODO
-    // /// Gets the root svg element in the document hierarchy.
-    // abstract rootElement: SVGSVGElement with get, set
-    // /// Retrieves a collection of styleSheet objects representing the style sheets that correspond to each instance of a link or style object in the document.
-    // abstract styleSheets: StyleSheetList with get, set
     // abstract createExpression: expression: string * resolver: XPathNSResolver -> XPathExpression
     // abstract createNSResolver: nodeResolver: Node -> XPathNSResolver
     // abstract evaluate: expression: string * contextNode: Node * resolver: XPathNSResolver * ``type``: float * result: XPathResult -> XPathResult
@@ -813,13 +813,13 @@ type [<AllowNullLiteral>] Window =
     inherit GlobalEventHandlers
     inherit WindowBase64
     // TODO
-    // abstract performance: Performance with get, set
+    abstract performance: Performance with get, set
     // abstract clientInformation: Navigator with get, set
     // abstract crypto: Crypto with get, set
     // abstract navigator: Navigator with get, set
-    // abstract styleMedia: StyleMedia with get, set
-    // abstract getComputedStyle: elt: Element * ?pseudoElt: string -> CSSStyleDeclaration
-    // abstract getMatchedCSSRules: elt: Element * ?pseudoElt: string -> CSSRuleList
+    abstract styleMedia: StyleMedia with get, set
+    abstract getComputedStyle: elt: Element * ?pseudoElt: string -> CSSStyleDeclaration
+    abstract getMatchedCSSRules: elt: Element * ?pseudoElt: string -> CSSRuleList
     // abstract matchMedia: mediaQuery: string -> MediaQueryList
     abstract animationStartTime: float with get, set
     abstract closed: bool with get, set
@@ -1289,7 +1289,7 @@ type [<AllowNullLiteral>] HTMLDocumentType =
 type [<AllowNullLiteral>] HTMLElement =
     inherit Element
     // TODO
-    // abstract style: CSSStyleDeclaration with get, set
+    abstract style: CSSStyleDeclaration with get, set
     abstract accessKey: string with get, set
     abstract children: HTMLCollection with get, set
     abstract contentEditable: string with get, set
@@ -1792,7 +1792,7 @@ type [<AllowNullLiteral>] HTMLLegendElementType =
 type [<AllowNullLiteral>] HTMLLinkElement =
     inherit HTMLElement
     // TODO
-    // inherit LinkStyle
+    inherit LinkStyle
     /// Sets or retrieves the character set used to encode the object.
     abstract charset: string with get, set
     abstract disabled: bool with get, set
@@ -2188,7 +2188,7 @@ type [<AllowNullLiteral>] HTMLSpanElementType =
 type [<AllowNullLiteral>] HTMLStyleElement =
     inherit HTMLElement
     // TODO
-    // inherit LinkStyle
+    inherit LinkStyle
     /// Sets or retrieves the media type.
     abstract media: string with get, set
     abstract ``type``: string with get, set
@@ -2969,3 +2969,2324 @@ type [<AllowNullLiteral>] WheelEvent =
 //     abstract DOM_DELTA_PAGE: float
 //     abstract DOM_DELTA_PIXEL: float
 //     [<Emit("new $0($1...)")>] abstract Create: typeArg: string * ?eventInitDict: WheelEventInit -> WheelEvent
+
+// ## SVG Elements
+
+type [<AllowNullLiteral>] SVGAElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGURIReference
+    abstract target: SVGAnimatedString with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGAElementType =
+    abstract prototype: SVGAElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAElement
+
+and [<AllowNullLiteral>] SVGAngle =
+    abstract unitType: float with get, set
+    abstract value: float with get, set
+    abstract valueAsString: string with get, set
+    abstract valueInSpecifiedUnits: float with get, set
+    abstract SVG_ANGLETYPE_DEG: float with get, set
+    abstract SVG_ANGLETYPE_GRAD: float with get, set
+    abstract SVG_ANGLETYPE_RAD: float with get, set
+    abstract SVG_ANGLETYPE_UNKNOWN: float with get, set
+    abstract SVG_ANGLETYPE_UNSPECIFIED: float with get, set
+    abstract convertToSpecifiedUnits: unitType: float -> unit
+    abstract newValueSpecifiedUnits: unitType: float * valueInSpecifiedUnits: float -> unit
+
+and [<AllowNullLiteral>] SVGAngleType =
+    abstract prototype: SVGAngle with get, set
+    abstract SVG_ANGLETYPE_DEG: float with get, set
+    abstract SVG_ANGLETYPE_GRAD: float with get, set
+    abstract SVG_ANGLETYPE_RAD: float with get, set
+    abstract SVG_ANGLETYPE_UNKNOWN: float with get, set
+    abstract SVG_ANGLETYPE_UNSPECIFIED: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAngle
+
+and [<AllowNullLiteral>] SVGAnimatedAngle =
+    abstract animVal: SVGAngle with get, set
+    abstract baseVal: SVGAngle with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedAngleType =
+    abstract prototype: SVGAnimatedAngle with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedAngle
+
+and [<AllowNullLiteral>] SVGAnimatedBoolean =
+    abstract animVal: bool with get, set
+    abstract baseVal: bool with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedBooleanType =
+    abstract prototype: SVGAnimatedBoolean with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedBoolean
+
+and [<AllowNullLiteral>] SVGAnimatedEnumeration =
+    abstract animVal: float with get, set
+    abstract baseVal: float with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedEnumerationType =
+    abstract prototype: SVGAnimatedEnumeration with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedEnumeration
+
+and [<AllowNullLiteral>] SVGAnimatedInteger =
+    abstract animVal: float with get, set
+    abstract baseVal: float with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedIntegerType =
+    abstract prototype: SVGAnimatedInteger with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedInteger
+
+and [<AllowNullLiteral>] SVGAnimatedLength =
+    abstract animVal: SVGLength with get, set
+    abstract baseVal: SVGLength with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedLengthType =
+    abstract prototype: SVGAnimatedLength with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedLength
+
+and [<AllowNullLiteral>] SVGAnimatedLengthList =
+    abstract animVal: SVGLengthList with get, set
+    abstract baseVal: SVGLengthList with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedLengthListType =
+    abstract prototype: SVGAnimatedLengthList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedLengthList
+
+and [<AllowNullLiteral>] SVGAnimatedNumber =
+    abstract animVal: float with get, set
+    abstract baseVal: float with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedNumberType =
+    abstract prototype: SVGAnimatedNumber with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedNumber
+
+and [<AllowNullLiteral>] SVGAnimatedNumberList =
+    abstract animVal: SVGNumberList with get, set
+    abstract baseVal: SVGNumberList with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedNumberListType =
+    abstract prototype: SVGAnimatedNumberList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedNumberList
+
+and [<AllowNullLiteral>] SVGAnimatedPreserveAspectRatio =
+    abstract animVal: SVGPreserveAspectRatio with get, set
+    abstract baseVal: SVGPreserveAspectRatio with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedPreserveAspectRatioType =
+    abstract prototype: SVGAnimatedPreserveAspectRatio with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedPreserveAspectRatio
+
+and [<AllowNullLiteral>] SVGAnimatedRect =
+    abstract animVal: SVGRect with get, set
+    abstract baseVal: SVGRect with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedRectType =
+    abstract prototype: SVGAnimatedRect with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedRect
+
+and [<AllowNullLiteral>] SVGAnimatedString =
+    abstract animVal: string with get, set
+    abstract baseVal: string with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedStringType =
+    abstract prototype: SVGAnimatedString with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedString
+
+and [<AllowNullLiteral>] SVGAnimatedTransformList =
+    abstract animVal: SVGTransformList with get, set
+    abstract baseVal: SVGTransformList with get, set
+
+and [<AllowNullLiteral>] SVGAnimatedTransformListType =
+    abstract prototype: SVGAnimatedTransformList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGAnimatedTransformList
+
+and [<AllowNullLiteral>] SVGCircleElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    abstract cx: SVGAnimatedLength with get, set
+    abstract cy: SVGAnimatedLength with get, set
+    abstract r: SVGAnimatedLength with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGCircleElementType =
+    abstract prototype: SVGCircleElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGCircleElement
+
+and [<AllowNullLiteral>] SVGClipPathElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGUnitTypes
+    abstract clipPathUnits: SVGAnimatedEnumeration with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGClipPathElementType =
+    abstract prototype: SVGClipPathElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGClipPathElement
+
+and [<AllowNullLiteral>] SVGComponentTransferFunctionElement =
+    inherit SVGElement
+    abstract amplitude: SVGAnimatedNumber with get, set
+    abstract exponent: SVGAnimatedNumber with get, set
+    abstract intercept: SVGAnimatedNumber with get, set
+    abstract offset: SVGAnimatedNumber with get, set
+    abstract slope: SVGAnimatedNumber with get, set
+    abstract tableValues: SVGAnimatedNumberList with get, set
+    abstract ``type``: SVGAnimatedEnumeration with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_DISCRETE: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_GAMMA: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_LINEAR: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_TABLE: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_UNKNOWN: float with get, set
+
+and [<AllowNullLiteral>] SVGComponentTransferFunctionElementType =
+    abstract prototype: SVGComponentTransferFunctionElement with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_DISCRETE: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_GAMMA: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_LINEAR: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_TABLE: float with get, set
+    abstract SVG_FECOMPONENTTRANSFER_TYPE_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGComponentTransferFunctionElement
+
+and [<AllowNullLiteral>] SVGDefsElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGDefsElementType =
+    abstract prototype: SVGDefsElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGDefsElement
+
+and [<AllowNullLiteral>] SVGDescElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGLangSpace
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGDescElementType =
+    abstract prototype: SVGDescElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGDescElement
+
+and [<AllowNullLiteral>] SVGElement =
+    inherit Element
+    abstract id: string with get, set
+    abstract onclick: (MouseEvent -> 'Out) with get, set
+    abstract ondblclick: (MouseEvent -> 'Out) with get, set
+    abstract onfocusin: (FocusEvent -> 'Out) with get, set
+    abstract onfocusout: (FocusEvent -> 'Out) with get, set
+    abstract onload: (Event -> 'Out) with get, set
+    abstract onmousedown: (MouseEvent -> 'Out) with get, set
+    abstract onmousemove: (MouseEvent -> 'Out) with get, set
+    abstract onmouseout: (MouseEvent -> 'Out) with get, set
+    abstract onmouseover: (MouseEvent -> 'Out) with get, set
+    abstract onmouseup: (MouseEvent -> 'Out) with get, set
+    abstract ownerSVGElement: SVGSVGElement with get, set
+    abstract viewportElement: SVGElement with get, set
+    abstract xmlbase: string with get, set
+    abstract className: obj with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGElementType =
+    abstract prototype: SVGElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGElement
+
+and [<AllowNullLiteral>] SVGElementInstance =
+    inherit EventTarget
+    abstract childNodes: SVGElementInstanceList with get, set
+    abstract correspondingElement: SVGElement with get, set
+    abstract correspondingUseElement: SVGUseElement with get, set
+    abstract firstChild: SVGElementInstance with get, set
+    abstract lastChild: SVGElementInstance with get, set
+    abstract nextSibling: SVGElementInstance with get, set
+    abstract parentNode: SVGElementInstance with get, set
+    abstract previousSibling: SVGElementInstance with get, set
+
+and [<AllowNullLiteral>] SVGElementInstanceType =
+    abstract prototype: SVGElementInstance with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGElementInstance
+
+and [<AllowNullLiteral>] SVGElementInstanceList =
+    abstract length: float with get, set
+    abstract item: index: float -> SVGElementInstance
+
+and [<AllowNullLiteral>] SVGElementInstanceListType =
+    abstract prototype: SVGElementInstanceList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGElementInstanceList
+
+and [<AllowNullLiteral>] SVGEllipseElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    abstract cx: SVGAnimatedLength with get, set
+    abstract cy: SVGAnimatedLength with get, set
+    abstract rx: SVGAnimatedLength with get, set
+    abstract ry: SVGAnimatedLength with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGEllipseElementType =
+    abstract prototype: SVGEllipseElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGEllipseElement
+
+and [<AllowNullLiteral>] SVGFEBlendElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract in1: SVGAnimatedString with get, set
+    abstract in2: SVGAnimatedString with get, set
+    abstract mode: SVGAnimatedEnumeration with get, set
+    abstract SVG_FEBLEND_MODE_COLOR: float with get, set
+    abstract SVG_FEBLEND_MODE_COLOR_BURN: float with get, set
+    abstract SVG_FEBLEND_MODE_COLOR_DODGE: float with get, set
+    abstract SVG_FEBLEND_MODE_DARKEN: float with get, set
+    abstract SVG_FEBLEND_MODE_DIFFERENCE: float with get, set
+    abstract SVG_FEBLEND_MODE_EXCLUSION: float with get, set
+    abstract SVG_FEBLEND_MODE_HARD_LIGHT: float with get, set
+    abstract SVG_FEBLEND_MODE_HUE: float with get, set
+    abstract SVG_FEBLEND_MODE_LIGHTEN: float with get, set
+    abstract SVG_FEBLEND_MODE_LUMINOSITY: float with get, set
+    abstract SVG_FEBLEND_MODE_MULTIPLY: float with get, set
+    abstract SVG_FEBLEND_MODE_NORMAL: float with get, set
+    abstract SVG_FEBLEND_MODE_OVERLAY: float with get, set
+    abstract SVG_FEBLEND_MODE_SATURATION: float with get, set
+    abstract SVG_FEBLEND_MODE_SCREEN: float with get, set
+    abstract SVG_FEBLEND_MODE_SOFT_LIGHT: float with get, set
+    abstract SVG_FEBLEND_MODE_UNKNOWN: float with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEBlendElementType =
+    abstract prototype: SVGFEBlendElement with get, set
+    abstract SVG_FEBLEND_MODE_COLOR: float with get, set
+    abstract SVG_FEBLEND_MODE_COLOR_BURN: float with get, set
+    abstract SVG_FEBLEND_MODE_COLOR_DODGE: float with get, set
+    abstract SVG_FEBLEND_MODE_DARKEN: float with get, set
+    abstract SVG_FEBLEND_MODE_DIFFERENCE: float with get, set
+    abstract SVG_FEBLEND_MODE_EXCLUSION: float with get, set
+    abstract SVG_FEBLEND_MODE_HARD_LIGHT: float with get, set
+    abstract SVG_FEBLEND_MODE_HUE: float with get, set
+    abstract SVG_FEBLEND_MODE_LIGHTEN: float with get, set
+    abstract SVG_FEBLEND_MODE_LUMINOSITY: float with get, set
+    abstract SVG_FEBLEND_MODE_MULTIPLY: float with get, set
+    abstract SVG_FEBLEND_MODE_NORMAL: float with get, set
+    abstract SVG_FEBLEND_MODE_OVERLAY: float with get, set
+    abstract SVG_FEBLEND_MODE_SATURATION: float with get, set
+    abstract SVG_FEBLEND_MODE_SCREEN: float with get, set
+    abstract SVG_FEBLEND_MODE_SOFT_LIGHT: float with get, set
+    abstract SVG_FEBLEND_MODE_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEBlendElement
+
+and [<AllowNullLiteral>] SVGFEColorMatrixElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract in1: SVGAnimatedString with get, set
+    abstract ``type``: SVGAnimatedEnumeration with get, set
+    abstract values: SVGAnimatedNumberList with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_HUEROTATE: float with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_LUMINANCETOALPHA: float with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_MATRIX: float with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_SATURATE: float with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_UNKNOWN: float with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEColorMatrixElementType =
+    abstract prototype: SVGFEColorMatrixElement with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_HUEROTATE: float with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_LUMINANCETOALPHA: float with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_MATRIX: float with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_SATURATE: float with get, set
+    abstract SVG_FECOLORMATRIX_TYPE_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEColorMatrixElement
+
+and [<AllowNullLiteral>] SVGFEComponentTransferElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract in1: SVGAnimatedString with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEComponentTransferElementType =
+    abstract prototype: SVGFEComponentTransferElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEComponentTransferElement
+
+and [<AllowNullLiteral>] SVGFECompositeElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract in1: SVGAnimatedString with get, set
+    abstract in2: SVGAnimatedString with get, set
+    abstract k1: SVGAnimatedNumber with get, set
+    abstract k2: SVGAnimatedNumber with get, set
+    abstract k3: SVGAnimatedNumber with get, set
+    abstract k4: SVGAnimatedNumber with get, set
+    abstract operator: SVGAnimatedEnumeration with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_ARITHMETIC: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_ATOP: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_IN: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_OUT: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_OVER: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_UNKNOWN: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_XOR: float with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFECompositeElementType =
+    abstract prototype: SVGFECompositeElement with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_ARITHMETIC: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_ATOP: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_IN: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_OUT: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_OVER: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_UNKNOWN: float with get, set
+    abstract SVG_FECOMPOSITE_OPERATOR_XOR: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFECompositeElement
+
+and [<AllowNullLiteral>] SVGFEConvolveMatrixElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract bias: SVGAnimatedNumber with get, set
+    abstract divisor: SVGAnimatedNumber with get, set
+    abstract edgeMode: SVGAnimatedEnumeration with get, set
+    abstract in1: SVGAnimatedString with get, set
+    abstract kernelMatrix: SVGAnimatedNumberList with get, set
+    abstract kernelUnitLengthX: SVGAnimatedNumber with get, set
+    abstract kernelUnitLengthY: SVGAnimatedNumber with get, set
+    abstract orderX: SVGAnimatedInteger with get, set
+    abstract orderY: SVGAnimatedInteger with get, set
+    abstract preserveAlpha: SVGAnimatedBoolean with get, set
+    abstract targetX: SVGAnimatedInteger with get, set
+    abstract targetY: SVGAnimatedInteger with get, set
+    abstract SVG_EDGEMODE_DUPLICATE: float with get, set
+    abstract SVG_EDGEMODE_NONE: float with get, set
+    abstract SVG_EDGEMODE_UNKNOWN: float with get, set
+    abstract SVG_EDGEMODE_WRAP: float with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEConvolveMatrixElementType =
+    abstract prototype: SVGFEConvolveMatrixElement with get, set
+    abstract SVG_EDGEMODE_DUPLICATE: float with get, set
+    abstract SVG_EDGEMODE_NONE: float with get, set
+    abstract SVG_EDGEMODE_UNKNOWN: float with get, set
+    abstract SVG_EDGEMODE_WRAP: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEConvolveMatrixElement
+
+and [<AllowNullLiteral>] SVGFEDiffuseLightingElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract diffuseConstant: SVGAnimatedNumber with get, set
+    abstract in1: SVGAnimatedString with get, set
+    abstract kernelUnitLengthX: SVGAnimatedNumber with get, set
+    abstract kernelUnitLengthY: SVGAnimatedNumber with get, set
+    abstract surfaceScale: SVGAnimatedNumber with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEDiffuseLightingElementType =
+    abstract prototype: SVGFEDiffuseLightingElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEDiffuseLightingElement
+
+and [<AllowNullLiteral>] SVGFEDisplacementMapElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract in1: SVGAnimatedString with get, set
+    abstract in2: SVGAnimatedString with get, set
+    abstract scale: SVGAnimatedNumber with get, set
+    abstract xChannelSelector: SVGAnimatedEnumeration with get, set
+    abstract yChannelSelector: SVGAnimatedEnumeration with get, set
+    abstract SVG_CHANNEL_A: float with get, set
+    abstract SVG_CHANNEL_B: float with get, set
+    abstract SVG_CHANNEL_G: float with get, set
+    abstract SVG_CHANNEL_R: float with get, set
+    abstract SVG_CHANNEL_UNKNOWN: float with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEDisplacementMapElementType =
+    abstract prototype: SVGFEDisplacementMapElement with get, set
+    abstract SVG_CHANNEL_A: float with get, set
+    abstract SVG_CHANNEL_B: float with get, set
+    abstract SVG_CHANNEL_G: float with get, set
+    abstract SVG_CHANNEL_R: float with get, set
+    abstract SVG_CHANNEL_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEDisplacementMapElement
+
+and [<AllowNullLiteral>] SVGFEDistantLightElement =
+    inherit SVGElement
+    abstract azimuth: SVGAnimatedNumber with get, set
+    abstract elevation: SVGAnimatedNumber with get, set
+
+and [<AllowNullLiteral>] SVGFEDistantLightElementType =
+    abstract prototype: SVGFEDistantLightElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEDistantLightElement
+
+and [<AllowNullLiteral>] SVGFEFloodElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEFloodElementType =
+    abstract prototype: SVGFEFloodElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEFloodElement
+
+and [<AllowNullLiteral>] SVGFEFuncAElement =
+    inherit SVGComponentTransferFunctionElement
+
+
+and [<AllowNullLiteral>] SVGFEFuncAElementType =
+    abstract prototype: SVGFEFuncAElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEFuncAElement
+
+and [<AllowNullLiteral>] SVGFEFuncBElement =
+    inherit SVGComponentTransferFunctionElement
+
+
+and [<AllowNullLiteral>] SVGFEFuncBElementType =
+    abstract prototype: SVGFEFuncBElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEFuncBElement
+
+and [<AllowNullLiteral>] SVGFEFuncGElement =
+    inherit SVGComponentTransferFunctionElement
+
+
+and [<AllowNullLiteral>] SVGFEFuncGElementType =
+    abstract prototype: SVGFEFuncGElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEFuncGElement
+
+and [<AllowNullLiteral>] SVGFEFuncRElement =
+    inherit SVGComponentTransferFunctionElement
+
+
+and [<AllowNullLiteral>] SVGFEFuncRElementType =
+    abstract prototype: SVGFEFuncRElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEFuncRElement
+
+and [<AllowNullLiteral>] SVGFEGaussianBlurElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract in1: SVGAnimatedString with get, set
+    abstract stdDeviationX: SVGAnimatedNumber with get, set
+    abstract stdDeviationY: SVGAnimatedNumber with get, set
+    abstract setStdDeviation: stdDeviationX: float * stdDeviationY: float -> unit
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEGaussianBlurElementType =
+    abstract prototype: SVGFEGaussianBlurElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEGaussianBlurElement
+
+and [<AllowNullLiteral>] SVGFEImageElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    inherit SVGLangSpace
+    inherit SVGURIReference
+    inherit SVGExternalResourcesRequired
+    abstract preserveAspectRatio: SVGAnimatedPreserveAspectRatio with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEImageElementType =
+    abstract prototype: SVGFEImageElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEImageElement
+
+and [<AllowNullLiteral>] SVGFEMergeElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEMergeElementType =
+    abstract prototype: SVGFEMergeElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEMergeElement
+
+and [<AllowNullLiteral>] SVGFEMergeNodeElement =
+    inherit SVGElement
+    abstract in1: SVGAnimatedString with get, set
+
+and [<AllowNullLiteral>] SVGFEMergeNodeElementType =
+    abstract prototype: SVGFEMergeNodeElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEMergeNodeElement
+
+and [<AllowNullLiteral>] SVGFEMorphologyElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract in1: SVGAnimatedString with get, set
+    abstract operator: SVGAnimatedEnumeration with get, set
+    abstract radiusX: SVGAnimatedNumber with get, set
+    abstract radiusY: SVGAnimatedNumber with get, set
+    abstract SVG_MORPHOLOGY_OPERATOR_DILATE: float with get, set
+    abstract SVG_MORPHOLOGY_OPERATOR_ERODE: float with get, set
+    abstract SVG_MORPHOLOGY_OPERATOR_UNKNOWN: float with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEMorphologyElementType =
+    abstract prototype: SVGFEMorphologyElement with get, set
+    abstract SVG_MORPHOLOGY_OPERATOR_DILATE: float with get, set
+    abstract SVG_MORPHOLOGY_OPERATOR_ERODE: float with get, set
+    abstract SVG_MORPHOLOGY_OPERATOR_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEMorphologyElement
+
+and [<AllowNullLiteral>] SVGFEOffsetElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract dx: SVGAnimatedNumber with get, set
+    abstract dy: SVGAnimatedNumber with get, set
+    abstract in1: SVGAnimatedString with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFEOffsetElementType =
+    abstract prototype: SVGFEOffsetElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEOffsetElement
+
+and [<AllowNullLiteral>] SVGFEPointLightElement =
+    inherit SVGElement
+    abstract x: SVGAnimatedNumber with get, set
+    abstract y: SVGAnimatedNumber with get, set
+    abstract z: SVGAnimatedNumber with get, set
+
+and [<AllowNullLiteral>] SVGFEPointLightElementType =
+    abstract prototype: SVGFEPointLightElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFEPointLightElement
+
+and [<AllowNullLiteral>] SVGFESpecularLightingElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract in1: SVGAnimatedString with get, set
+    abstract kernelUnitLengthX: SVGAnimatedNumber with get, set
+    abstract kernelUnitLengthY: SVGAnimatedNumber with get, set
+    abstract specularConstant: SVGAnimatedNumber with get, set
+    abstract specularExponent: SVGAnimatedNumber with get, set
+    abstract surfaceScale: SVGAnimatedNumber with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFESpecularLightingElementType =
+    abstract prototype: SVGFESpecularLightingElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFESpecularLightingElement
+
+and [<AllowNullLiteral>] SVGFESpotLightElement =
+    inherit SVGElement
+    abstract limitingConeAngle: SVGAnimatedNumber with get, set
+    abstract pointsAtX: SVGAnimatedNumber with get, set
+    abstract pointsAtY: SVGAnimatedNumber with get, set
+    abstract pointsAtZ: SVGAnimatedNumber with get, set
+    abstract specularExponent: SVGAnimatedNumber with get, set
+    abstract x: SVGAnimatedNumber with get, set
+    abstract y: SVGAnimatedNumber with get, set
+    abstract z: SVGAnimatedNumber with get, set
+
+and [<AllowNullLiteral>] SVGFESpotLightElementType =
+    abstract prototype: SVGFESpotLightElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFESpotLightElement
+
+and [<AllowNullLiteral>] SVGFETileElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract in1: SVGAnimatedString with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFETileElementType =
+    abstract prototype: SVGFETileElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFETileElement
+
+and [<AllowNullLiteral>] SVGFETurbulenceElement =
+    inherit SVGElement
+    inherit SVGFilterPrimitiveStandardAttributes
+    abstract baseFrequencyX: SVGAnimatedNumber with get, set
+    abstract baseFrequencyY: SVGAnimatedNumber with get, set
+    abstract numOctaves: SVGAnimatedInteger with get, set
+    abstract seed: SVGAnimatedNumber with get, set
+    abstract stitchTiles: SVGAnimatedEnumeration with get, set
+    abstract ``type``: SVGAnimatedEnumeration with get, set
+    abstract SVG_STITCHTYPE_NOSTITCH: float with get, set
+    abstract SVG_STITCHTYPE_STITCH: float with get, set
+    abstract SVG_STITCHTYPE_UNKNOWN: float with get, set
+    abstract SVG_TURBULENCE_TYPE_FRACTALNOISE: float with get, set
+    abstract SVG_TURBULENCE_TYPE_TURBULENCE: float with get, set
+    abstract SVG_TURBULENCE_TYPE_UNKNOWN: float with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFETurbulenceElementType =
+    abstract prototype: SVGFETurbulenceElement with get, set
+    abstract SVG_STITCHTYPE_NOSTITCH: float with get, set
+    abstract SVG_STITCHTYPE_STITCH: float with get, set
+    abstract SVG_STITCHTYPE_UNKNOWN: float with get, set
+    abstract SVG_TURBULENCE_TYPE_FRACTALNOISE: float with get, set
+    abstract SVG_TURBULENCE_TYPE_TURBULENCE: float with get, set
+    abstract SVG_TURBULENCE_TYPE_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFETurbulenceElement
+
+and [<AllowNullLiteral>] SVGFilterElement =
+    inherit SVGElement
+    inherit SVGUnitTypes
+    inherit SVGStylable
+    inherit SVGLangSpace
+    inherit SVGURIReference
+    inherit SVGExternalResourcesRequired
+    abstract filterResX: SVGAnimatedInteger with get, set
+    abstract filterResY: SVGAnimatedInteger with get, set
+    abstract filterUnits: SVGAnimatedEnumeration with get, set
+    abstract height: SVGAnimatedLength with get, set
+    abstract primitiveUnits: SVGAnimatedEnumeration with get, set
+    abstract width: SVGAnimatedLength with get, set
+    abstract x: SVGAnimatedLength with get, set
+    abstract y: SVGAnimatedLength with get, set
+    abstract setFilterRes: filterResX: float * filterResY: float -> unit
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGFilterElementType =
+    abstract prototype: SVGFilterElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGFilterElement
+
+and [<AllowNullLiteral>] SVGForeignObjectElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    abstract height: SVGAnimatedLength with get, set
+    abstract width: SVGAnimatedLength with get, set
+    abstract x: SVGAnimatedLength with get, set
+    abstract y: SVGAnimatedLength with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGForeignObjectElementType =
+    abstract prototype: SVGForeignObjectElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGForeignObjectElement
+
+and [<AllowNullLiteral>] SVGGElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGGElementType =
+    abstract prototype: SVGGElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGGElement
+
+and [<AllowNullLiteral>] SVGGradientElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGExternalResourcesRequired
+    inherit SVGURIReference
+    inherit SVGUnitTypes
+    abstract gradientTransform: SVGAnimatedTransformList with get, set
+    abstract gradientUnits: SVGAnimatedEnumeration with get, set
+    abstract spreadMethod: SVGAnimatedEnumeration with get, set
+    abstract SVG_SPREADMETHOD_PAD: float with get, set
+    abstract SVG_SPREADMETHOD_REFLECT: float with get, set
+    abstract SVG_SPREADMETHOD_REPEAT: float with get, set
+    abstract SVG_SPREADMETHOD_UNKNOWN: float with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGGradientElementType =
+    abstract prototype: SVGGradientElement with get, set
+    abstract SVG_SPREADMETHOD_PAD: float with get, set
+    abstract SVG_SPREADMETHOD_REFLECT: float with get, set
+    abstract SVG_SPREADMETHOD_REPEAT: float with get, set
+    abstract SVG_SPREADMETHOD_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGGradientElement
+
+and [<AllowNullLiteral>] SVGImageElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGURIReference
+    abstract height: SVGAnimatedLength with get, set
+    abstract preserveAspectRatio: SVGAnimatedPreserveAspectRatio with get, set
+    abstract width: SVGAnimatedLength with get, set
+    abstract x: SVGAnimatedLength with get, set
+    abstract y: SVGAnimatedLength with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGImageElementType =
+    abstract prototype: SVGImageElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGImageElement
+
+and [<AllowNullLiteral>] SVGLength =
+    abstract unitType: float with get, set
+    abstract value: float with get, set
+    abstract valueAsString: string with get, set
+    abstract valueInSpecifiedUnits: float with get, set
+    abstract SVG_LENGTHTYPE_CM: float with get, set
+    abstract SVG_LENGTHTYPE_EMS: float with get, set
+    abstract SVG_LENGTHTYPE_EXS: float with get, set
+    abstract SVG_LENGTHTYPE_IN: float with get, set
+    abstract SVG_LENGTHTYPE_MM: float with get, set
+    abstract SVG_LENGTHTYPE_NUMBER: float with get, set
+    abstract SVG_LENGTHTYPE_PC: float with get, set
+    abstract SVG_LENGTHTYPE_PERCENTAGE: float with get, set
+    abstract SVG_LENGTHTYPE_PT: float with get, set
+    abstract SVG_LENGTHTYPE_PX: float with get, set
+    abstract SVG_LENGTHTYPE_UNKNOWN: float with get, set
+    abstract convertToSpecifiedUnits: unitType: float -> unit
+    abstract newValueSpecifiedUnits: unitType: float * valueInSpecifiedUnits: float -> unit
+
+and [<AllowNullLiteral>] SVGLengthType =
+    abstract prototype: SVGLength with get, set
+    abstract SVG_LENGTHTYPE_CM: float with get, set
+    abstract SVG_LENGTHTYPE_EMS: float with get, set
+    abstract SVG_LENGTHTYPE_EXS: float with get, set
+    abstract SVG_LENGTHTYPE_IN: float with get, set
+    abstract SVG_LENGTHTYPE_MM: float with get, set
+    abstract SVG_LENGTHTYPE_NUMBER: float with get, set
+    abstract SVG_LENGTHTYPE_PC: float with get, set
+    abstract SVG_LENGTHTYPE_PERCENTAGE: float with get, set
+    abstract SVG_LENGTHTYPE_PT: float with get, set
+    abstract SVG_LENGTHTYPE_PX: float with get, set
+    abstract SVG_LENGTHTYPE_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGLength
+
+and [<AllowNullLiteral>] SVGLengthList =
+    abstract numberOfItems: float with get, set
+    abstract appendItem: newItem: SVGLength -> SVGLength
+    abstract clear: unit -> unit
+    abstract getItem: index: float -> SVGLength
+    abstract initialize: newItem: SVGLength -> SVGLength
+    abstract insertItemBefore: newItem: SVGLength * index: float -> SVGLength
+    abstract removeItem: index: float -> SVGLength
+    abstract replaceItem: newItem: SVGLength * index: float -> SVGLength
+
+and [<AllowNullLiteral>] SVGLengthListType =
+    abstract prototype: SVGLengthList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGLengthList
+
+and [<AllowNullLiteral>] SVGLineElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    abstract x1: SVGAnimatedLength with get, set
+    abstract x2: SVGAnimatedLength with get, set
+    abstract y1: SVGAnimatedLength with get, set
+    abstract y2: SVGAnimatedLength with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGLineElementType =
+    abstract prototype: SVGLineElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGLineElement
+
+and [<AllowNullLiteral>] SVGLinearGradientElement =
+    inherit SVGGradientElement
+    abstract x1: SVGAnimatedLength with get, set
+    abstract x2: SVGAnimatedLength with get, set
+    abstract y1: SVGAnimatedLength with get, set
+    abstract y2: SVGAnimatedLength with get, set
+
+and [<AllowNullLiteral>] SVGLinearGradientElementType =
+    abstract prototype: SVGLinearGradientElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGLinearGradientElement
+
+and [<AllowNullLiteral>] SVGMarkerElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGFitToViewBox
+    abstract markerHeight: SVGAnimatedLength with get, set
+    abstract markerUnits: SVGAnimatedEnumeration with get, set
+    abstract markerWidth: SVGAnimatedLength with get, set
+    abstract orientAngle: SVGAnimatedAngle with get, set
+    abstract orientType: SVGAnimatedEnumeration with get, set
+    abstract refX: SVGAnimatedLength with get, set
+    abstract refY: SVGAnimatedLength with get, set
+    abstract SVG_MARKERUNITS_STROKEWIDTH: float with get, set
+    abstract SVG_MARKERUNITS_UNKNOWN: float with get, set
+    abstract SVG_MARKERUNITS_USERSPACEONUSE: float with get, set
+    abstract SVG_MARKER_ORIENT_ANGLE: float with get, set
+    abstract SVG_MARKER_ORIENT_AUTO: float with get, set
+    abstract SVG_MARKER_ORIENT_UNKNOWN: float with get, set
+    abstract setOrientToAngle: angle: SVGAngle -> unit
+    abstract setOrientToAuto: unit -> unit
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGMarkerElementType =
+    abstract prototype: SVGMarkerElement with get, set
+    abstract SVG_MARKERUNITS_STROKEWIDTH: float with get, set
+    abstract SVG_MARKERUNITS_UNKNOWN: float with get, set
+    abstract SVG_MARKERUNITS_USERSPACEONUSE: float with get, set
+    abstract SVG_MARKER_ORIENT_ANGLE: float with get, set
+    abstract SVG_MARKER_ORIENT_AUTO: float with get, set
+    abstract SVG_MARKER_ORIENT_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGMarkerElement
+
+and [<AllowNullLiteral>] SVGMaskElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGUnitTypes
+    abstract height: SVGAnimatedLength with get, set
+    abstract maskContentUnits: SVGAnimatedEnumeration with get, set
+    abstract maskUnits: SVGAnimatedEnumeration with get, set
+    abstract width: SVGAnimatedLength with get, set
+    abstract x: SVGAnimatedLength with get, set
+    abstract y: SVGAnimatedLength with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGMaskElementType =
+    abstract prototype: SVGMaskElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGMaskElement
+
+and [<AllowNullLiteral>] SVGMatrix =
+    abstract a: float with get, set
+    abstract b: float with get, set
+    abstract c: float with get, set
+    abstract d: float with get, set
+    abstract e: float with get, set
+    abstract f: float with get, set
+    abstract flipX: unit -> SVGMatrix
+    abstract flipY: unit -> SVGMatrix
+    abstract inverse: unit -> SVGMatrix
+    abstract multiply: secondMatrix: SVGMatrix -> SVGMatrix
+    abstract rotate: angle: float -> SVGMatrix
+    abstract rotateFromVector: x: float * y: float -> SVGMatrix
+    abstract scale: scaleFactor: float -> SVGMatrix
+    abstract scaleNonUniform: scaleFactorX: float * scaleFactorY: float -> SVGMatrix
+    abstract skewX: angle: float -> SVGMatrix
+    abstract skewY: angle: float -> SVGMatrix
+    abstract translate: x: float * y: float -> SVGMatrix
+
+and [<AllowNullLiteral>] SVGMatrixType =
+    abstract prototype: SVGMatrix with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGMatrix
+
+and [<AllowNullLiteral>] SVGMetadataElement =
+    inherit SVGElement
+
+
+and [<AllowNullLiteral>] SVGMetadataElementType =
+    abstract prototype: SVGMetadataElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGMetadataElement
+
+and [<AllowNullLiteral>] SVGNumber =
+    abstract value: float with get, set
+
+and [<AllowNullLiteral>] SVGNumberType =
+    abstract prototype: SVGNumber with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGNumber
+
+and [<AllowNullLiteral>] SVGNumberList =
+    abstract numberOfItems: float with get, set
+    abstract appendItem: newItem: SVGNumber -> SVGNumber
+    abstract clear: unit -> unit
+    abstract getItem: index: float -> SVGNumber
+    abstract initialize: newItem: SVGNumber -> SVGNumber
+    abstract insertItemBefore: newItem: SVGNumber * index: float -> SVGNumber
+    abstract removeItem: index: float -> SVGNumber
+    abstract replaceItem: newItem: SVGNumber * index: float -> SVGNumber
+
+and [<AllowNullLiteral>] SVGNumberListType =
+    abstract prototype: SVGNumberList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGNumberList
+
+and [<AllowNullLiteral>] SVGPathElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGAnimatedPathData
+    abstract createSVGPathSegArcAbs: x: float * y: float * r1: float * r2: float * angle: float * largeArcFlag: bool * sweepFlag: bool -> SVGPathSegArcAbs
+    abstract createSVGPathSegArcRel: x: float * y: float * r1: float * r2: float * angle: float * largeArcFlag: bool * sweepFlag: bool -> SVGPathSegArcRel
+    abstract createSVGPathSegClosePath: unit -> SVGPathSegClosePath
+    abstract createSVGPathSegCurvetoCubicAbs: x: float * y: float * x1: float * y1: float * x2: float * y2: float -> SVGPathSegCurvetoCubicAbs
+    abstract createSVGPathSegCurvetoCubicRel: x: float * y: float * x1: float * y1: float * x2: float * y2: float -> SVGPathSegCurvetoCubicRel
+    abstract createSVGPathSegCurvetoCubicSmoothAbs: x: float * y: float * x2: float * y2: float -> SVGPathSegCurvetoCubicSmoothAbs
+    abstract createSVGPathSegCurvetoCubicSmoothRel: x: float * y: float * x2: float * y2: float -> SVGPathSegCurvetoCubicSmoothRel
+    abstract createSVGPathSegCurvetoQuadraticAbs: x: float * y: float * x1: float * y1: float -> SVGPathSegCurvetoQuadraticAbs
+    abstract createSVGPathSegCurvetoQuadraticRel: x: float * y: float * x1: float * y1: float -> SVGPathSegCurvetoQuadraticRel
+    abstract createSVGPathSegCurvetoQuadraticSmoothAbs: x: float * y: float -> SVGPathSegCurvetoQuadraticSmoothAbs
+    abstract createSVGPathSegCurvetoQuadraticSmoothRel: x: float * y: float -> SVGPathSegCurvetoQuadraticSmoothRel
+    abstract createSVGPathSegLinetoAbs: x: float * y: float -> SVGPathSegLinetoAbs
+    abstract createSVGPathSegLinetoHorizontalAbs: x: float -> SVGPathSegLinetoHorizontalAbs
+    abstract createSVGPathSegLinetoHorizontalRel: x: float -> SVGPathSegLinetoHorizontalRel
+    abstract createSVGPathSegLinetoRel: x: float * y: float -> SVGPathSegLinetoRel
+    abstract createSVGPathSegLinetoVerticalAbs: y: float -> SVGPathSegLinetoVerticalAbs
+    abstract createSVGPathSegLinetoVerticalRel: y: float -> SVGPathSegLinetoVerticalRel
+    abstract createSVGPathSegMovetoAbs: x: float * y: float -> SVGPathSegMovetoAbs
+    abstract createSVGPathSegMovetoRel: x: float * y: float -> SVGPathSegMovetoRel
+    abstract getPathSegAtLength: distance: float -> float
+    abstract getPointAtLength: distance: float -> SVGPoint
+    abstract getTotalLength: unit -> float
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGPathElementType =
+    abstract prototype: SVGPathElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathElement
+
+and [<AllowNullLiteral>] SVGPathSeg =
+    abstract pathSegType: float with get, set
+    abstract pathSegTypeAsLetter: string with get, set
+    abstract PATHSEG_ARC_ABS: float with get, set
+    abstract PATHSEG_ARC_REL: float with get, set
+    abstract PATHSEG_CLOSEPATH: float with get, set
+    abstract PATHSEG_CURVETO_CUBIC_ABS: float with get, set
+    abstract PATHSEG_CURVETO_CUBIC_REL: float with get, set
+    abstract PATHSEG_CURVETO_CUBIC_SMOOTH_ABS: float with get, set
+    abstract PATHSEG_CURVETO_CUBIC_SMOOTH_REL: float with get, set
+    abstract PATHSEG_CURVETO_QUADRATIC_ABS: float with get, set
+    abstract PATHSEG_CURVETO_QUADRATIC_REL: float with get, set
+    abstract PATHSEG_CURVETO_QUADRATIC_SMOOTH_ABS: float with get, set
+    abstract PATHSEG_CURVETO_QUADRATIC_SMOOTH_REL: float with get, set
+    abstract PATHSEG_LINETO_ABS: float with get, set
+    abstract PATHSEG_LINETO_HORIZONTAL_ABS: float with get, set
+    abstract PATHSEG_LINETO_HORIZONTAL_REL: float with get, set
+    abstract PATHSEG_LINETO_REL: float with get, set
+    abstract PATHSEG_LINETO_VERTICAL_ABS: float with get, set
+    abstract PATHSEG_LINETO_VERTICAL_REL: float with get, set
+    abstract PATHSEG_MOVETO_ABS: float with get, set
+    abstract PATHSEG_MOVETO_REL: float with get, set
+    abstract PATHSEG_UNKNOWN: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegType =
+    abstract prototype: SVGPathSeg with get, set
+    abstract PATHSEG_ARC_ABS: float with get, set
+    abstract PATHSEG_ARC_REL: float with get, set
+    abstract PATHSEG_CLOSEPATH: float with get, set
+    abstract PATHSEG_CURVETO_CUBIC_ABS: float with get, set
+    abstract PATHSEG_CURVETO_CUBIC_REL: float with get, set
+    abstract PATHSEG_CURVETO_CUBIC_SMOOTH_ABS: float with get, set
+    abstract PATHSEG_CURVETO_CUBIC_SMOOTH_REL: float with get, set
+    abstract PATHSEG_CURVETO_QUADRATIC_ABS: float with get, set
+    abstract PATHSEG_CURVETO_QUADRATIC_REL: float with get, set
+    abstract PATHSEG_CURVETO_QUADRATIC_SMOOTH_ABS: float with get, set
+    abstract PATHSEG_CURVETO_QUADRATIC_SMOOTH_REL: float with get, set
+    abstract PATHSEG_LINETO_ABS: float with get, set
+    abstract PATHSEG_LINETO_HORIZONTAL_ABS: float with get, set
+    abstract PATHSEG_LINETO_HORIZONTAL_REL: float with get, set
+    abstract PATHSEG_LINETO_REL: float with get, set
+    abstract PATHSEG_LINETO_VERTICAL_ABS: float with get, set
+    abstract PATHSEG_LINETO_VERTICAL_REL: float with get, set
+    abstract PATHSEG_MOVETO_ABS: float with get, set
+    abstract PATHSEG_MOVETO_REL: float with get, set
+    abstract PATHSEG_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSeg
+
+and [<AllowNullLiteral>] SVGPathSegArcAbs =
+    inherit SVGPathSeg
+    abstract angle: float with get, set
+    abstract largeArcFlag: bool with get, set
+    abstract r1: float with get, set
+    abstract r2: float with get, set
+    abstract sweepFlag: bool with get, set
+    abstract x: float with get, set
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegArcAbsType =
+    abstract prototype: SVGPathSegArcAbs with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegArcAbs
+
+and [<AllowNullLiteral>] SVGPathSegArcRel =
+    inherit SVGPathSeg
+    abstract angle: float with get, set
+    abstract largeArcFlag: bool with get, set
+    abstract r1: float with get, set
+    abstract r2: float with get, set
+    abstract sweepFlag: bool with get, set
+    abstract x: float with get, set
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegArcRelType =
+    abstract prototype: SVGPathSegArcRel with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegArcRel
+
+and [<AllowNullLiteral>] SVGPathSegClosePath =
+    inherit SVGPathSeg
+
+
+and [<AllowNullLiteral>] SVGPathSegClosePathType =
+    abstract prototype: SVGPathSegClosePath with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegClosePath
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoCubicAbs =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract x1: float with get, set
+    abstract x2: float with get, set
+    abstract y: float with get, set
+    abstract y1: float with get, set
+    abstract y2: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoCubicAbsType =
+    abstract prototype: SVGPathSegCurvetoCubicAbs with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegCurvetoCubicAbs
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoCubicRel =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract x1: float with get, set
+    abstract x2: float with get, set
+    abstract y: float with get, set
+    abstract y1: float with get, set
+    abstract y2: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoCubicRelType =
+    abstract prototype: SVGPathSegCurvetoCubicRel with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegCurvetoCubicRel
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoCubicSmoothAbs =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract x2: float with get, set
+    abstract y: float with get, set
+    abstract y2: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoCubicSmoothAbsType =
+    abstract prototype: SVGPathSegCurvetoCubicSmoothAbs with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegCurvetoCubicSmoothAbs
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoCubicSmoothRel =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract x2: float with get, set
+    abstract y: float with get, set
+    abstract y2: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoCubicSmoothRelType =
+    abstract prototype: SVGPathSegCurvetoCubicSmoothRel with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegCurvetoCubicSmoothRel
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoQuadraticAbs =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract x1: float with get, set
+    abstract y: float with get, set
+    abstract y1: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoQuadraticAbsType =
+    abstract prototype: SVGPathSegCurvetoQuadraticAbs with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegCurvetoQuadraticAbs
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoQuadraticRel =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract x1: float with get, set
+    abstract y: float with get, set
+    abstract y1: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoQuadraticRelType =
+    abstract prototype: SVGPathSegCurvetoQuadraticRel with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegCurvetoQuadraticRel
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoQuadraticSmoothAbs =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoQuadraticSmoothAbsType =
+    abstract prototype: SVGPathSegCurvetoQuadraticSmoothAbs with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegCurvetoQuadraticSmoothAbs
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoQuadraticSmoothRel =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegCurvetoQuadraticSmoothRelType =
+    abstract prototype: SVGPathSegCurvetoQuadraticSmoothRel with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegCurvetoQuadraticSmoothRel
+
+and [<AllowNullLiteral>] SVGPathSegLinetoAbs =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegLinetoAbsType =
+    abstract prototype: SVGPathSegLinetoAbs with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegLinetoAbs
+
+and [<AllowNullLiteral>] SVGPathSegLinetoHorizontalAbs =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegLinetoHorizontalAbsType =
+    abstract prototype: SVGPathSegLinetoHorizontalAbs with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegLinetoHorizontalAbs
+
+and [<AllowNullLiteral>] SVGPathSegLinetoHorizontalRel =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegLinetoHorizontalRelType =
+    abstract prototype: SVGPathSegLinetoHorizontalRel with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegLinetoHorizontalRel
+
+and [<AllowNullLiteral>] SVGPathSegLinetoRel =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegLinetoRelType =
+    abstract prototype: SVGPathSegLinetoRel with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegLinetoRel
+
+and [<AllowNullLiteral>] SVGPathSegLinetoVerticalAbs =
+    inherit SVGPathSeg
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegLinetoVerticalAbsType =
+    abstract prototype: SVGPathSegLinetoVerticalAbs with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegLinetoVerticalAbs
+
+and [<AllowNullLiteral>] SVGPathSegLinetoVerticalRel =
+    inherit SVGPathSeg
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegLinetoVerticalRelType =
+    abstract prototype: SVGPathSegLinetoVerticalRel with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegLinetoVerticalRel
+
+and [<AllowNullLiteral>] SVGPathSegList =
+    abstract numberOfItems: float with get, set
+    abstract appendItem: newItem: SVGPathSeg -> SVGPathSeg
+    abstract clear: unit -> unit
+    abstract getItem: index: float -> SVGPathSeg
+    abstract initialize: newItem: SVGPathSeg -> SVGPathSeg
+    abstract insertItemBefore: newItem: SVGPathSeg * index: float -> SVGPathSeg
+    abstract removeItem: index: float -> SVGPathSeg
+    abstract replaceItem: newItem: SVGPathSeg * index: float -> SVGPathSeg
+
+and [<AllowNullLiteral>] SVGPathSegListType =
+    abstract prototype: SVGPathSegList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegList
+
+and [<AllowNullLiteral>] SVGPathSegMovetoAbs =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegMovetoAbsType =
+    abstract prototype: SVGPathSegMovetoAbs with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegMovetoAbs
+
+and [<AllowNullLiteral>] SVGPathSegMovetoRel =
+    inherit SVGPathSeg
+    abstract x: float with get, set
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGPathSegMovetoRelType =
+    abstract prototype: SVGPathSegMovetoRel with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPathSegMovetoRel
+
+and [<AllowNullLiteral>] SVGPatternElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGFitToViewBox
+    inherit SVGURIReference
+    inherit SVGUnitTypes
+    abstract height: SVGAnimatedLength with get, set
+    abstract patternContentUnits: SVGAnimatedEnumeration with get, set
+    abstract patternTransform: SVGAnimatedTransformList with get, set
+    abstract patternUnits: SVGAnimatedEnumeration with get, set
+    abstract width: SVGAnimatedLength with get, set
+    abstract x: SVGAnimatedLength with get, set
+    abstract y: SVGAnimatedLength with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGPatternElementType =
+    abstract prototype: SVGPatternElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPatternElement
+
+and [<AllowNullLiteral>] SVGPoint =
+    abstract x: float with get, set
+    abstract y: float with get, set
+    abstract matrixTransform: matrix: SVGMatrix -> SVGPoint
+
+and [<AllowNullLiteral>] SVGPointType =
+    abstract prototype: SVGPoint with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPoint
+
+and [<AllowNullLiteral>] SVGPointList =
+    abstract numberOfItems: float with get, set
+    abstract appendItem: newItem: SVGPoint -> SVGPoint
+    abstract clear: unit -> unit
+    abstract getItem: index: float -> SVGPoint
+    abstract initialize: newItem: SVGPoint -> SVGPoint
+    abstract insertItemBefore: newItem: SVGPoint * index: float -> SVGPoint
+    abstract removeItem: index: float -> SVGPoint
+    abstract replaceItem: newItem: SVGPoint * index: float -> SVGPoint
+
+and [<AllowNullLiteral>] SVGPointListType =
+    abstract prototype: SVGPointList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPointList
+
+and [<AllowNullLiteral>] SVGPolygonElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGAnimatedPoints
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGPolygonElementType =
+    abstract prototype: SVGPolygonElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPolygonElement
+
+and [<AllowNullLiteral>] SVGPolylineElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGAnimatedPoints
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGPolylineElementType =
+    abstract prototype: SVGPolylineElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPolylineElement
+
+and [<AllowNullLiteral>] SVGPreserveAspectRatio =
+    abstract align: float with get, set
+    abstract meetOrSlice: float with get, set
+    abstract SVG_MEETORSLICE_MEET: float with get, set
+    abstract SVG_MEETORSLICE_SLICE: float with get, set
+    abstract SVG_MEETORSLICE_UNKNOWN: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_NONE: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_UNKNOWN: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMAXYMAX: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMAXYMID: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMAXYMIN: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMIDYMAX: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMIDYMID: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMIDYMIN: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMINYMAX: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMINYMID: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMINYMIN: float with get, set
+
+and [<AllowNullLiteral>] SVGPreserveAspectRatioType =
+    abstract prototype: SVGPreserveAspectRatio with get, set
+    abstract SVG_MEETORSLICE_MEET: float with get, set
+    abstract SVG_MEETORSLICE_SLICE: float with get, set
+    abstract SVG_MEETORSLICE_UNKNOWN: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_NONE: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_UNKNOWN: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMAXYMAX: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMAXYMID: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMAXYMIN: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMIDYMAX: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMIDYMID: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMIDYMIN: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMINYMAX: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMINYMID: float with get, set
+    abstract SVG_PRESERVEASPECTRATIO_XMINYMIN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGPreserveAspectRatio
+
+and [<AllowNullLiteral>] SVGRadialGradientElement =
+    inherit SVGGradientElement
+    abstract cx: SVGAnimatedLength with get, set
+    abstract cy: SVGAnimatedLength with get, set
+    abstract fx: SVGAnimatedLength with get, set
+    abstract fy: SVGAnimatedLength with get, set
+    abstract r: SVGAnimatedLength with get, set
+
+and [<AllowNullLiteral>] SVGRadialGradientElementType =
+    abstract prototype: SVGRadialGradientElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGRadialGradientElement
+
+and [<AllowNullLiteral>] SVGRect =
+    abstract height: float with get, set
+    abstract width: float with get, set
+    abstract x: float with get, set
+    abstract y: float with get, set
+
+and [<AllowNullLiteral>] SVGRectType =
+    abstract prototype: SVGRect with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGRect
+
+and [<AllowNullLiteral>] SVGRectElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    abstract height: SVGAnimatedLength with get, set
+    abstract rx: SVGAnimatedLength with get, set
+    abstract ry: SVGAnimatedLength with get, set
+    abstract width: SVGAnimatedLength with get, set
+    abstract x: SVGAnimatedLength with get, set
+    abstract y: SVGAnimatedLength with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGRectElementType =
+    abstract prototype: SVGRectElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGRectElement
+
+and [<AllowNullLiteral>] SVGSVGElement =
+    inherit SVGElement
+    inherit DocumentEvent
+    inherit SVGLocatable
+    inherit SVGTests
+    inherit SVGStylable
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGFitToViewBox
+    inherit SVGZoomAndPan
+    abstract contentScriptType: string with get, set
+    abstract contentStyleType: string with get, set
+    abstract currentScale: float with get, set
+    abstract currentTranslate: SVGPoint with get, set
+    abstract height: SVGAnimatedLength with get, set
+    abstract onabort: (Event -> 'Out) with get, set
+    abstract onerror: (Event -> 'Out) with get, set
+    abstract onresize: (UIEvent -> 'Out) with get, set
+    abstract onscroll: (UIEvent -> 'Out) with get, set
+    abstract onunload: (Event -> 'Out) with get, set
+    abstract onzoom: (SVGZoomEvent -> 'Out) with get, set
+    abstract pixelUnitToMillimeterX: float with get, set
+    abstract pixelUnitToMillimeterY: float with get, set
+    abstract screenPixelToMillimeterX: float with get, set
+    abstract screenPixelToMillimeterY: float with get, set
+    abstract viewport: SVGRect with get, set
+    abstract width: SVGAnimatedLength with get, set
+    abstract x: SVGAnimatedLength with get, set
+    abstract y: SVGAnimatedLength with get, set
+    abstract checkEnclosure: element: SVGElement * rect: SVGRect -> bool
+    abstract checkIntersection: element: SVGElement * rect: SVGRect -> bool
+    abstract createSVGAngle: unit -> SVGAngle
+    abstract createSVGLength: unit -> SVGLength
+    abstract createSVGMatrix: unit -> SVGMatrix
+    abstract createSVGNumber: unit -> SVGNumber
+    abstract createSVGPoint: unit -> SVGPoint
+    abstract createSVGRect: unit -> SVGRect
+    abstract createSVGTransform: unit -> SVGTransform
+    abstract createSVGTransformFromMatrix: matrix: SVGMatrix -> SVGTransform
+    abstract deselectAll: unit -> unit
+    abstract forceRedraw: unit -> unit
+    abstract getComputedStyle: elt: Element * ?pseudoElt: string -> CSSStyleDeclaration
+    abstract getCurrentTime: unit -> float
+    abstract getElementById: elementId: string -> Element
+    abstract getEnclosureList: rect: SVGRect * referenceElement: SVGElement -> NodeList
+    abstract getIntersectionList: rect: SVGRect * referenceElement: SVGElement -> NodeList
+    abstract pauseAnimations: unit -> unit
+    abstract setCurrentTime: seconds: float -> unit
+    abstract suspendRedraw: maxWaitMilliseconds: float -> float
+    abstract unpauseAnimations: unit -> unit
+    abstract unsuspendRedraw: suspendHandleID: float -> unit
+    abstract unsuspendRedrawAll: unit -> unit
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGSVGElementType =
+    abstract prototype: SVGSVGElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGSVGElement
+
+and [<AllowNullLiteral>] SVGScriptElement =
+    inherit SVGElement
+    inherit SVGExternalResourcesRequired
+    inherit SVGURIReference
+    abstract ``type``: string with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGScriptElementType =
+    abstract prototype: SVGScriptElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGScriptElement
+
+and [<AllowNullLiteral>] SVGStopElement =
+    inherit SVGElement
+    inherit SVGStylable
+    abstract offset: SVGAnimatedNumber with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGStopElementType =
+    abstract prototype: SVGStopElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGStopElement
+
+and [<AllowNullLiteral>] SVGStringList =
+    abstract numberOfItems: float with get, set
+    abstract appendItem: newItem: string -> string
+    abstract clear: unit -> unit
+    abstract getItem: index: float -> string
+    abstract initialize: newItem: string -> string
+    abstract insertItemBefore: newItem: string * index: float -> string
+    abstract removeItem: index: float -> string
+    abstract replaceItem: newItem: string * index: float -> string
+
+and [<AllowNullLiteral>] SVGStringListType =
+    abstract prototype: SVGStringList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGStringList
+
+and [<AllowNullLiteral>] SVGStyleElement =
+    inherit SVGElement
+    inherit SVGLangSpace
+    abstract media: string with get, set
+    abstract title: string with get, set
+    abstract ``type``: string with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGStyleElementType =
+    abstract prototype: SVGStyleElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGStyleElement
+
+and [<AllowNullLiteral>] SVGSwitchElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGSwitchElementType =
+    abstract prototype: SVGSwitchElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGSwitchElement
+
+and [<AllowNullLiteral>] SVGSymbolElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGFitToViewBox
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGSymbolElementType =
+    abstract prototype: SVGSymbolElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGSymbolElement
+
+and [<AllowNullLiteral>] SVGTSpanElement =
+    inherit SVGTextPositioningElement
+
+
+and [<AllowNullLiteral>] SVGTSpanElementType =
+    abstract prototype: SVGTSpanElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGTSpanElement
+
+and [<AllowNullLiteral>] SVGTextContentElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    abstract lengthAdjust: SVGAnimatedEnumeration with get, set
+    abstract textLength: SVGAnimatedLength with get, set
+    abstract LENGTHADJUST_SPACING: float with get, set
+    abstract LENGTHADJUST_SPACINGANDGLYPHS: float with get, set
+    abstract LENGTHADJUST_UNKNOWN: float with get, set
+    abstract getCharNumAtPosition: point: SVGPoint -> float
+    abstract getComputedTextLength: unit -> float
+    abstract getEndPositionOfChar: charnum: float -> SVGPoint
+    abstract getExtentOfChar: charnum: float -> SVGRect
+    abstract getNumberOfChars: unit -> float
+    abstract getRotationOfChar: charnum: float -> float
+    abstract getStartPositionOfChar: charnum: float -> SVGPoint
+    abstract getSubStringLength: charnum: float * nchars: float -> float
+    abstract selectSubString: charnum: float * nchars: float -> unit
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGTextContentElementType =
+    abstract prototype: SVGTextContentElement with get, set
+    abstract LENGTHADJUST_SPACING: float with get, set
+    abstract LENGTHADJUST_SPACINGANDGLYPHS: float with get, set
+    abstract LENGTHADJUST_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGTextContentElement
+
+and [<AllowNullLiteral>] SVGTextElement =
+    inherit SVGTextPositioningElement
+    inherit SVGTransformable
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGTextElementType =
+    abstract prototype: SVGTextElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGTextElement
+
+and [<AllowNullLiteral>] SVGTextPathElement =
+    inherit SVGTextContentElement
+    inherit SVGURIReference
+    abstract ``method``: SVGAnimatedEnumeration with get, set
+    abstract spacing: SVGAnimatedEnumeration with get, set
+    abstract startOffset: SVGAnimatedLength with get, set
+    abstract TEXTPATH_METHODTYPE_ALIGN: float with get, set
+    abstract TEXTPATH_METHODTYPE_STRETCH: float with get, set
+    abstract TEXTPATH_METHODTYPE_UNKNOWN: float with get, set
+    abstract TEXTPATH_SPACINGTYPE_AUTO: float with get, set
+    abstract TEXTPATH_SPACINGTYPE_EXACT: float with get, set
+    abstract TEXTPATH_SPACINGTYPE_UNKNOWN: float with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGTextPathElementType =
+    abstract prototype: SVGTextPathElement with get, set
+    abstract TEXTPATH_METHODTYPE_ALIGN: float with get, set
+    abstract TEXTPATH_METHODTYPE_STRETCH: float with get, set
+    abstract TEXTPATH_METHODTYPE_UNKNOWN: float with get, set
+    abstract TEXTPATH_SPACINGTYPE_AUTO: float with get, set
+    abstract TEXTPATH_SPACINGTYPE_EXACT: float with get, set
+    abstract TEXTPATH_SPACINGTYPE_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGTextPathElement
+
+and [<AllowNullLiteral>] SVGTextPositioningElement =
+    inherit SVGTextContentElement
+    abstract dx: SVGAnimatedLengthList with get, set
+    abstract dy: SVGAnimatedLengthList with get, set
+    abstract rotate: SVGAnimatedNumberList with get, set
+    abstract x: SVGAnimatedLengthList with get, set
+    abstract y: SVGAnimatedLengthList with get, set
+
+and [<AllowNullLiteral>] SVGTextPositioningElementType =
+    abstract prototype: SVGTextPositioningElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGTextPositioningElement
+
+and [<AllowNullLiteral>] SVGTitleElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGLangSpace
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGTitleElementType =
+    abstract prototype: SVGTitleElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGTitleElement
+
+and [<AllowNullLiteral>] SVGTransform =
+    abstract angle: float with get, set
+    abstract matrix: SVGMatrix with get, set
+    abstract ``type``: float with get, set
+    abstract SVG_TRANSFORM_MATRIX: float with get, set
+    abstract SVG_TRANSFORM_ROTATE: float with get, set
+    abstract SVG_TRANSFORM_SCALE: float with get, set
+    abstract SVG_TRANSFORM_SKEWX: float with get, set
+    abstract SVG_TRANSFORM_SKEWY: float with get, set
+    abstract SVG_TRANSFORM_TRANSLATE: float with get, set
+    abstract SVG_TRANSFORM_UNKNOWN: float with get, set
+    abstract setMatrix: matrix: SVGMatrix -> unit
+    abstract setRotate: angle: float * cx: float * cy: float -> unit
+    abstract setScale: sx: float * sy: float -> unit
+    abstract setSkewX: angle: float -> unit
+    abstract setSkewY: angle: float -> unit
+    abstract setTranslate: tx: float * ty: float -> unit
+
+and [<AllowNullLiteral>] SVGTransformType =
+    abstract prototype: SVGTransform with get, set
+    abstract SVG_TRANSFORM_MATRIX: float with get, set
+    abstract SVG_TRANSFORM_ROTATE: float with get, set
+    abstract SVG_TRANSFORM_SCALE: float with get, set
+    abstract SVG_TRANSFORM_SKEWX: float with get, set
+    abstract SVG_TRANSFORM_SKEWY: float with get, set
+    abstract SVG_TRANSFORM_TRANSLATE: float with get, set
+    abstract SVG_TRANSFORM_UNKNOWN: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGTransform
+
+and [<AllowNullLiteral>] SVGTransformList =
+    abstract numberOfItems: float with get, set
+    abstract appendItem: newItem: SVGTransform -> SVGTransform
+    abstract clear: unit -> unit
+    abstract consolidate: unit -> SVGTransform
+    abstract createSVGTransformFromMatrix: matrix: SVGMatrix -> SVGTransform
+    abstract getItem: index: float -> SVGTransform
+    abstract initialize: newItem: SVGTransform -> SVGTransform
+    abstract insertItemBefore: newItem: SVGTransform * index: float -> SVGTransform
+    abstract removeItem: index: float -> SVGTransform
+    abstract replaceItem: newItem: SVGTransform * index: float -> SVGTransform
+
+and [<AllowNullLiteral>] SVGTransformListType =
+    abstract prototype: SVGTransformList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGTransformList
+
+and [<AllowNullLiteral>] SVGUnitTypes =
+    abstract SVG_UNIT_TYPE_OBJECTBOUNDINGBOX: float with get, set
+    abstract SVG_UNIT_TYPE_UNKNOWN: float with get, set
+    abstract SVG_UNIT_TYPE_USERSPACEONUSE: float with get, set
+
+and [<AllowNullLiteral>] SVGUseElement =
+    inherit SVGElement
+    inherit SVGStylable
+    inherit SVGTransformable
+    inherit SVGTests
+    inherit SVGLangSpace
+    inherit SVGExternalResourcesRequired
+    inherit SVGURIReference
+    abstract animatedInstanceRoot: SVGElementInstance with get, set
+    abstract height: SVGAnimatedLength with get, set
+    abstract instanceRoot: SVGElementInstance with get, set
+    abstract width: SVGAnimatedLength with get, set
+    abstract x: SVGAnimatedLength with get, set
+    abstract y: SVGAnimatedLength with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGUseElementType =
+    abstract prototype: SVGUseElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGUseElement
+
+and [<AllowNullLiteral>] SVGViewElement =
+    inherit SVGElement
+    inherit SVGExternalResourcesRequired
+    inherit SVGFitToViewBox
+    inherit SVGZoomAndPan
+    abstract viewTarget: SVGStringList with get, set
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
+
+and [<AllowNullLiteral>] SVGViewElementType =
+    abstract prototype: SVGViewElement with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGViewElement
+
+and [<AllowNullLiteral>] SVGZoomAndPan =
+    abstract zoomAndPan: float with get, set
+
+and [<AllowNullLiteral>] SVGZoomAndPanType =
+    abstract SVG_ZOOMANDPAN_DISABLE: float with get, set
+    abstract SVG_ZOOMANDPAN_MAGNIFY: float with get, set
+    abstract SVG_ZOOMANDPAN_UNKNOWN: float with get, set
+
+and [<AllowNullLiteral>] SVGZoomEvent =
+    inherit UIEvent
+    abstract newScale: float with get, set
+    abstract newTranslate: SVGPoint with get, set
+    abstract previousScale: float with get, set
+    abstract previousTranslate: SVGPoint with get, set
+    abstract zoomRectScreen: SVGRect with get, set
+
+and [<AllowNullLiteral>] SVGZoomEventType =
+    abstract prototype: SVGZoomEvent with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> SVGZoomEvent
+
+and [<AllowNullLiteral>] SVGAnimatedPathData =
+        abstract pathSegList: SVGPathSegList with get, set
+
+    and [<AllowNullLiteral>] SVGAnimatedPoints =
+        abstract animatedPoints: SVGPointList with get, set
+        abstract points: SVGPointList with get, set
+
+    and [<AllowNullLiteral>] SVGExternalResourcesRequired =
+        abstract externalResourcesRequired: SVGAnimatedBoolean with get, set
+
+    and [<AllowNullLiteral>] SVGFilterPrimitiveStandardAttributes =
+        inherit SVGStylable
+        abstract height: SVGAnimatedLength with get, set
+        abstract result: SVGAnimatedString with get, set
+        abstract width: SVGAnimatedLength with get, set
+        abstract x: SVGAnimatedLength with get, set
+        abstract y: SVGAnimatedLength with get, set
+
+    and [<AllowNullLiteral>] SVGFitToViewBox =
+        abstract preserveAspectRatio: SVGAnimatedPreserveAspectRatio with get, set
+        abstract viewBox: SVGAnimatedRect with get, set
+
+    and [<AllowNullLiteral>] SVGLangSpace =
+        abstract xmllang: string with get, set
+        abstract xmlspace: string with get, set
+
+    and [<AllowNullLiteral>] SVGLocatable =
+        abstract farthestViewportElement: SVGElement with get, set
+        abstract nearestViewportElement: SVGElement with get, set
+        abstract getBBox: unit -> SVGRect
+        abstract getCTM: unit -> SVGMatrix
+        abstract getScreenCTM: unit -> SVGMatrix
+        abstract getTransformToElement: element: SVGElement -> SVGMatrix
+
+    and [<AllowNullLiteral>] SVGStylable =
+        abstract className: obj with get, set
+        abstract style: CSSStyleDeclaration with get, set
+
+    and [<AllowNullLiteral>] SVGTests =
+        abstract requiredExtensions: SVGStringList with get, set
+        abstract requiredFeatures: SVGStringList with get, set
+        abstract systemLanguage: SVGStringList with get, set
+        abstract hasExtension: extension: string -> bool
+
+    and [<AllowNullLiteral>] SVGTransformable =
+        inherit SVGLocatable
+        abstract transform: SVGAnimatedTransformList with get, set
+
+    and [<AllowNullLiteral>] SVGURIReference =
+        abstract href: SVGAnimatedString with get, set
+
+// ## CSS
+
+type [<AllowNullLiteral>] LinkStyle =
+    abstract sheet: StyleSheet with get, set
+
+type [<AllowNullLiteral>] CSS =
+    abstract supports: property: string * ?value: string -> bool
+
+type [<AllowNullLiteral>] CSSConditionRule =
+    inherit CSSGroupingRule
+    abstract conditionText: string with get, set
+
+type [<AllowNullLiteral>] CSSConditionRuleType =
+    abstract prototype: CSSConditionRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSConditionRule
+
+type [<AllowNullLiteral>] CSSFontFaceRule =
+    inherit CSSRule
+    abstract style: CSSStyleDeclaration with get, set
+
+type [<AllowNullLiteral>] CSSFontFaceRuleType =
+    abstract prototype: CSSFontFaceRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSFontFaceRule
+
+type [<AllowNullLiteral>] CSSGroupingRule =
+    inherit CSSRule
+    abstract cssRules: CSSRuleList with get, set
+    abstract deleteRule: ?index: float -> unit
+    abstract insertRule: rule: string * ?index: float -> float
+
+type [<AllowNullLiteral>] CSSGroupingRuleType =
+    abstract prototype: CSSGroupingRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSGroupingRule
+
+type [<AllowNullLiteral>] CSSImportRule =
+    inherit CSSRule
+    abstract href: string with get, set
+    // TODO
+    // abstract media: MediaList with get, set
+    abstract styleSheet: CSSStyleSheet with get, set
+
+type [<AllowNullLiteral>] CSSImportRuleType =
+    abstract prototype: CSSImportRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSImportRule
+
+type [<AllowNullLiteral>] CSSKeyframeRule =
+    inherit CSSRule
+    abstract keyText: string with get, set
+    abstract style: CSSStyleDeclaration with get, set
+
+type [<AllowNullLiteral>] CSSKeyframeRuleType =
+    abstract prototype: CSSKeyframeRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSKeyframeRule
+
+type [<AllowNullLiteral>] CSSKeyframesRule =
+    inherit CSSRule
+    abstract cssRules: CSSRuleList with get, set
+    abstract name: string with get, set
+    abstract appendRule: rule: string -> unit
+    abstract deleteRule: rule: string -> unit
+    abstract findRule: rule: string -> CSSKeyframeRule
+
+type [<AllowNullLiteral>] CSSKeyframesRuleType =
+    abstract prototype: CSSKeyframesRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSKeyframesRule
+
+type [<AllowNullLiteral>] CSSMediaRule =
+    inherit CSSConditionRule
+    /// TODO
+    // abstract media: MediaList with get, set
+
+type [<AllowNullLiteral>] CSSMediaRuleType =
+    abstract prototype: CSSMediaRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSMediaRule
+
+type [<AllowNullLiteral>] CSSNamespaceRule =
+    inherit CSSRule
+    abstract namespaceURI: string with get, set
+    abstract prefix: string with get, set
+
+type [<AllowNullLiteral>] CSSNamespaceRuleType =
+    abstract prototype: CSSNamespaceRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSNamespaceRule
+
+type [<AllowNullLiteral>] CSSPageRule =
+    inherit CSSRule
+    abstract pseudoClass: string with get, set
+    abstract selector: string with get, set
+    abstract selectorText: string with get, set
+    abstract style: CSSStyleDeclaration with get, set
+
+type [<AllowNullLiteral>] CSSPageRuleType =
+    abstract prototype: CSSPageRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSPageRule
+
+type [<AllowNullLiteral>] CSSRule =
+    abstract cssText: string with get, set
+    abstract parentRule: CSSRule with get, set
+    abstract parentStyleSheet: CSSStyleSheet with get, set
+    abstract ``type``: float with get, set
+    abstract CHARSET_RULE: float with get, set
+    abstract FONT_FACE_RULE: float with get, set
+    abstract IMPORT_RULE: float with get, set
+    abstract KEYFRAMES_RULE: float with get, set
+    abstract KEYFRAME_RULE: float with get, set
+    abstract MEDIA_RULE: float with get, set
+    abstract NAMESPACE_RULE: float with get, set
+    abstract PAGE_RULE: float with get, set
+    abstract STYLE_RULE: float with get, set
+    abstract SUPPORTS_RULE: float with get, set
+    abstract UNKNOWN_RULE: float with get, set
+    abstract VIEWPORT_RULE: float with get, set
+
+type [<AllowNullLiteral>] CSSRuleType =
+    abstract prototype: CSSRule with get, set
+    abstract CHARSET_RULE: float with get, set
+    abstract FONT_FACE_RULE: float with get, set
+    abstract IMPORT_RULE: float with get, set
+    abstract KEYFRAMES_RULE: float with get, set
+    abstract KEYFRAME_RULE: float with get, set
+    abstract MEDIA_RULE: float with get, set
+    abstract NAMESPACE_RULE: float with get, set
+    abstract PAGE_RULE: float with get, set
+    abstract STYLE_RULE: float with get, set
+    abstract SUPPORTS_RULE: float with get, set
+    abstract UNKNOWN_RULE: float with get, set
+    abstract VIEWPORT_RULE: float with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSRule
+
+type [<AllowNullLiteral>] CSSRuleList =
+    abstract length: float with get, set
+    [<Emit("$0[$1]{{=$2}}")>] abstract Item: index: int -> CSSRule with get, set
+    abstract item: index: float -> CSSRule
+
+type [<AllowNullLiteral>] CSSRuleListType =
+    abstract prototype: CSSRuleList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSRuleList
+
+type [<AllowNullLiteral>] CSSStyleDeclaration =
+    abstract alignContent: string with get, set
+    abstract alignItems: string with get, set
+    abstract alignSelf: string with get, set
+    abstract alignmentBaseline: string with get, set
+    abstract animation: string with get, set
+    abstract animationDelay: string with get, set
+    abstract animationDirection: string with get, set
+    abstract animationDuration: string with get, set
+    abstract animationFillMode: string with get, set
+    abstract animationIterationCount: string with get, set
+    abstract animationName: string with get, set
+    abstract animationPlayState: string with get, set
+    abstract animationTimingFunction: string with get, set
+    abstract backfaceVisibility: string with get, set
+    abstract background: string with get, set
+    abstract backgroundAttachment: string with get, set
+    abstract backgroundClip: string with get, set
+    abstract backgroundColor: string with get, set
+    abstract backgroundImage: string with get, set
+    abstract backgroundOrigin: string with get, set
+    abstract backgroundPosition: string with get, set
+    abstract backgroundPositionX: string with get, set
+    abstract backgroundPositionY: string with get, set
+    abstract backgroundRepeat: string with get, set
+    abstract backgroundSize: string with get, set
+    abstract baselineShift: string with get, set
+    abstract border: string with get, set
+    abstract borderBottom: string with get, set
+    abstract borderBottomColor: string with get, set
+    abstract borderBottomLeftRadius: string with get, set
+    abstract borderBottomRightRadius: string with get, set
+    abstract borderBottomStyle: string with get, set
+    abstract borderBottomWidth: string with get, set
+    abstract borderCollapse: string with get, set
+    abstract borderColor: string with get, set
+    abstract borderImage: string with get, set
+    abstract borderImageOutset: string with get, set
+    abstract borderImageRepeat: string with get, set
+    abstract borderImageSlice: string with get, set
+    abstract borderImageSource: string with get, set
+    abstract borderImageWidth: string with get, set
+    abstract borderLeft: string with get, set
+    abstract borderLeftColor: string with get, set
+    abstract borderLeftStyle: string with get, set
+    abstract borderLeftWidth: string with get, set
+    abstract borderRadius: string with get, set
+    abstract borderRight: string with get, set
+    abstract borderRightColor: string with get, set
+    abstract borderRightStyle: string with get, set
+    abstract borderRightWidth: string with get, set
+    abstract borderSpacing: string with get, set
+    abstract borderStyle: string with get, set
+    abstract borderTop: string with get, set
+    abstract borderTopColor: string with get, set
+    abstract borderTopLeftRadius: string with get, set
+    abstract borderTopRightRadius: string with get, set
+    abstract borderTopStyle: string with get, set
+    abstract borderTopWidth: string with get, set
+    abstract borderWidth: string with get, set
+    abstract bottom: string with get, set
+    abstract boxShadow: string with get, set
+    abstract boxSizing: string with get, set
+    abstract breakAfter: string with get, set
+    abstract breakBefore: string with get, set
+    abstract breakInside: string with get, set
+    abstract captionSide: string with get, set
+    abstract clear: string with get, set
+    abstract clip: string with get, set
+    abstract clipPath: string with get, set
+    abstract clipRule: string with get, set
+    abstract color: string with get, set
+    abstract colorInterpolationFilters: string with get, set
+    abstract columnCount: obj with get, set
+    abstract columnFill: string with get, set
+    abstract columnGap: obj with get, set
+    abstract columnRule: string with get, set
+    abstract columnRuleColor: obj with get, set
+    abstract columnRuleStyle: string with get, set
+    abstract columnRuleWidth: obj with get, set
+    abstract columnSpan: string with get, set
+    abstract columnWidth: obj with get, set
+    abstract columns: string with get, set
+    abstract content: string with get, set
+    abstract counterIncrement: string with get, set
+    abstract counterReset: string with get, set
+    abstract cssFloat: string with get, set
+    abstract cssText: string with get, set
+    abstract cursor: string with get, set
+    abstract direction: string with get, set
+    abstract display: string with get, set
+    abstract dominantBaseline: string with get, set
+    abstract emptyCells: string with get, set
+    abstract enableBackground: string with get, set
+    abstract fill: string with get, set
+    abstract fillOpacity: string with get, set
+    abstract fillRule: string with get, set
+    abstract filter: string with get, set
+    abstract flex: string with get, set
+    abstract flexBasis: string with get, set
+    abstract flexDirection: string with get, set
+    abstract flexFlow: string with get, set
+    abstract flexGrow: string with get, set
+    abstract flexShrink: string with get, set
+    abstract flexWrap: string with get, set
+    abstract floodColor: string with get, set
+    abstract floodOpacity: string with get, set
+    abstract font: string with get, set
+    abstract fontFamily: string with get, set
+    abstract fontFeatureSettings: string with get, set
+    abstract fontSize: string with get, set
+    abstract fontSizeAdjust: string with get, set
+    abstract fontStretch: string with get, set
+    abstract fontStyle: string with get, set
+    abstract fontVariant: string with get, set
+    abstract fontWeight: string with get, set
+    abstract glyphOrientationHorizontal: string with get, set
+    abstract glyphOrientationVertical: string with get, set
+    abstract height: string with get, set
+    abstract imeMode: string with get, set
+    abstract justifyContent: string with get, set
+    abstract kerning: string with get, set
+    abstract left: string with get, set
+    abstract length: float with get, set
+    abstract letterSpacing: string with get, set
+    abstract lightingColor: string with get, set
+    abstract lineHeight: string with get, set
+    abstract listStyle: string with get, set
+    abstract listStyleImage: string with get, set
+    abstract listStylePosition: string with get, set
+    abstract listStyleType: string with get, set
+    abstract margin: string with get, set
+    abstract marginBottom: string with get, set
+    abstract marginLeft: string with get, set
+    abstract marginRight: string with get, set
+    abstract marginTop: string with get, set
+    abstract marker: string with get, set
+    abstract markerEnd: string with get, set
+    abstract markerMid: string with get, set
+    abstract markerStart: string with get, set
+    abstract mask: string with get, set
+    abstract maxHeight: string with get, set
+    abstract maxWidth: string with get, set
+    abstract minHeight: string with get, set
+    abstract minWidth: string with get, set
+    abstract msContentZoomChaining: string with get, set
+    abstract msContentZoomLimit: string with get, set
+    abstract msContentZoomLimitMax: obj with get, set
+    abstract msContentZoomLimitMin: obj with get, set
+    abstract msContentZoomSnap: string with get, set
+    abstract msContentZoomSnapPoints: string with get, set
+    abstract msContentZoomSnapType: string with get, set
+    abstract msContentZooming: string with get, set
+    abstract msFlowFrom: string with get, set
+    abstract msFlowInto: string with get, set
+    abstract msFontFeatureSettings: string with get, set
+    abstract msGridColumn: obj with get, set
+    abstract msGridColumnAlign: string with get, set
+    abstract msGridColumnSpan: obj with get, set
+    abstract msGridColumns: string with get, set
+    abstract msGridRow: obj with get, set
+    abstract msGridRowAlign: string with get, set
+    abstract msGridRowSpan: obj with get, set
+    abstract msGridRows: string with get, set
+    abstract msHighContrastAdjust: string with get, set
+    abstract msHyphenateLimitChars: string with get, set
+    abstract msHyphenateLimitLines: obj with get, set
+    abstract msHyphenateLimitZone: obj with get, set
+    abstract msHyphens: string with get, set
+    abstract msImeAlign: string with get, set
+    abstract msOverflowStyle: string with get, set
+    abstract msScrollChaining: string with get, set
+    abstract msScrollLimit: string with get, set
+    abstract msScrollLimitXMax: obj with get, set
+    abstract msScrollLimitXMin: obj with get, set
+    abstract msScrollLimitYMax: obj with get, set
+    abstract msScrollLimitYMin: obj with get, set
+    abstract msScrollRails: string with get, set
+    abstract msScrollSnapPointsX: string with get, set
+    abstract msScrollSnapPointsY: string with get, set
+    abstract msScrollSnapType: string with get, set
+    abstract msScrollSnapX: string with get, set
+    abstract msScrollSnapY: string with get, set
+    abstract msScrollTranslation: string with get, set
+    abstract msTextCombineHorizontal: string with get, set
+    abstract msTextSizeAdjust: obj with get, set
+    abstract msTouchAction: string with get, set
+    abstract msTouchSelect: string with get, set
+    abstract msUserSelect: string with get, set
+    abstract msWrapFlow: string with get, set
+    abstract msWrapMargin: obj with get, set
+    abstract msWrapThrough: string with get, set
+    abstract opacity: string with get, set
+    abstract order: string with get, set
+    abstract orphans: string with get, set
+    abstract outline: string with get, set
+    abstract outlineColor: string with get, set
+    abstract outlineStyle: string with get, set
+    abstract outlineWidth: string with get, set
+    abstract overflow: string with get, set
+    abstract overflowX: string with get, set
+    abstract overflowY: string with get, set
+    abstract padding: string with get, set
+    abstract paddingBottom: string with get, set
+    abstract paddingLeft: string with get, set
+    abstract paddingRight: string with get, set
+    abstract paddingTop: string with get, set
+    abstract pageBreakAfter: string with get, set
+    abstract pageBreakBefore: string with get, set
+    abstract pageBreakInside: string with get, set
+    abstract parentRule: CSSRule with get, set
+    abstract perspective: string with get, set
+    abstract perspectiveOrigin: string with get, set
+    abstract pointerEvents: string with get, set
+    abstract position: string with get, set
+    abstract quotes: string with get, set
+    abstract right: string with get, set
+    abstract rubyAlign: string with get, set
+    abstract rubyOverhang: string with get, set
+    abstract rubyPosition: string with get, set
+    abstract stopColor: string with get, set
+    abstract stopOpacity: string with get, set
+    abstract stroke: string with get, set
+    abstract strokeDasharray: string with get, set
+    abstract strokeDashoffset: string with get, set
+    abstract strokeLinecap: string with get, set
+    abstract strokeLinejoin: string with get, set
+    abstract strokeMiterlimit: string with get, set
+    abstract strokeOpacity: string with get, set
+    abstract strokeWidth: string with get, set
+    abstract tableLayout: string with get, set
+    abstract textAlign: string with get, set
+    abstract textAlignLast: string with get, set
+    abstract textAnchor: string with get, set
+    abstract textDecoration: string with get, set
+    abstract textFillColor: string with get, set
+    abstract textIndent: string with get, set
+    abstract textJustify: string with get, set
+    abstract textKashida: string with get, set
+    abstract textKashidaSpace: string with get, set
+    abstract textOverflow: string with get, set
+    abstract textShadow: string with get, set
+    abstract textTransform: string with get, set
+    abstract textUnderlinePosition: string with get, set
+    abstract top: string with get, set
+    abstract touchAction: string with get, set
+    abstract transform: string with get, set
+    abstract transformOrigin: string with get, set
+    abstract transformStyle: string with get, set
+    abstract transition: string with get, set
+    abstract transitionDelay: string with get, set
+    abstract transitionDuration: string with get, set
+    abstract transitionProperty: string with get, set
+    abstract transitionTimingFunction: string with get, set
+    abstract unicodeBidi: string with get, set
+    abstract verticalAlign: string with get, set
+    abstract visibility: string with get, set
+    abstract webkitAlignContent: string with get, set
+    abstract webkitAlignItems: string with get, set
+    abstract webkitAlignSelf: string with get, set
+    abstract webkitAnimation: string with get, set
+    abstract webkitAnimationDelay: string with get, set
+    abstract webkitAnimationDirection: string with get, set
+    abstract webkitAnimationDuration: string with get, set
+    abstract webkitAnimationFillMode: string with get, set
+    abstract webkitAnimationIterationCount: string with get, set
+    abstract webkitAnimationName: string with get, set
+    abstract webkitAnimationPlayState: string with get, set
+    abstract webkitAnimationTimingFunction: string with get, set
+    abstract webkitAppearance: string with get, set
+    abstract webkitBackfaceVisibility: string with get, set
+    abstract webkitBackground: string with get, set
+    abstract webkitBackgroundAttachment: string with get, set
+    abstract webkitBackgroundClip: string with get, set
+    abstract webkitBackgroundColor: string with get, set
+    abstract webkitBackgroundImage: string with get, set
+    abstract webkitBackgroundOrigin: string with get, set
+    abstract webkitBackgroundPosition: string with get, set
+    abstract webkitBackgroundPositionX: string with get, set
+    abstract webkitBackgroundPositionY: string with get, set
+    abstract webkitBackgroundRepeat: string with get, set
+    abstract webkitBackgroundSize: string with get, set
+    abstract webkitBorderBottomLeftRadius: string with get, set
+    abstract webkitBorderBottomRightRadius: string with get, set
+    abstract webkitBorderImage: string with get, set
+    abstract webkitBorderImageOutset: string with get, set
+    abstract webkitBorderImageRepeat: string with get, set
+    abstract webkitBorderImageSlice: string with get, set
+    abstract webkitBorderImageSource: string with get, set
+    abstract webkitBorderImageWidth: string with get, set
+    abstract webkitBorderRadius: string with get, set
+    abstract webkitBorderTopLeftRadius: string with get, set
+    abstract webkitBorderTopRightRadius: string with get, set
+    abstract webkitBoxAlign: string with get, set
+    abstract webkitBoxDirection: string with get, set
+    abstract webkitBoxFlex: string with get, set
+    abstract webkitBoxOrdinalGroup: string with get, set
+    abstract webkitBoxOrient: string with get, set
+    abstract webkitBoxPack: string with get, set
+    abstract webkitBoxSizing: string with get, set
+    abstract webkitColumnBreakAfter: string with get, set
+    abstract webkitColumnBreakBefore: string with get, set
+    abstract webkitColumnBreakInside: string with get, set
+    abstract webkitColumnCount: obj with get, set
+    abstract webkitColumnGap: obj with get, set
+    abstract webkitColumnRule: string with get, set
+    abstract webkitColumnRuleColor: obj with get, set
+    abstract webkitColumnRuleStyle: string with get, set
+    abstract webkitColumnRuleWidth: obj with get, set
+    abstract webkitColumnSpan: string with get, set
+    abstract webkitColumnWidth: obj with get, set
+    abstract webkitColumns: string with get, set
+    abstract webkitFilter: string with get, set
+    abstract webkitFlex: string with get, set
+    abstract webkitFlexBasis: string with get, set
+    abstract webkitFlexDirection: string with get, set
+    abstract webkitFlexFlow: string with get, set
+    abstract webkitFlexGrow: string with get, set
+    abstract webkitFlexShrink: string with get, set
+    abstract webkitFlexWrap: string with get, set
+    abstract webkitJustifyContent: string with get, set
+    abstract webkitOrder: string with get, set
+    abstract webkitPerspective: string with get, set
+    abstract webkitPerspectiveOrigin: string with get, set
+    abstract webkitTapHighlightColor: string with get, set
+    abstract webkitTextFillColor: string with get, set
+    abstract webkitTextSizeAdjust: obj with get, set
+    abstract webkitTransform: string with get, set
+    abstract webkitTransformOrigin: string with get, set
+    abstract webkitTransformStyle: string with get, set
+    abstract webkitTransition: string with get, set
+    abstract webkitTransitionDelay: string with get, set
+    abstract webkitTransitionDuration: string with get, set
+    abstract webkitTransitionProperty: string with get, set
+    abstract webkitTransitionTimingFunction: string with get, set
+    abstract webkitUserSelect: string with get, set
+    abstract webkitWritingMode: string with get, set
+    abstract whiteSpace: string with get, set
+    abstract widows: string with get, set
+    abstract width: string with get, set
+    abstract wordBreak: string with get, set
+    abstract wordSpacing: string with get, set
+    abstract wordWrap: string with get, set
+    abstract writingMode: string with get, set
+    abstract zIndex: string with get, set
+    abstract zoom: string with get, set
+    [<Emit("$0[$1]{{=$2}}")>] abstract Item: index: int -> string with get, set
+    abstract getPropertyPriority: propertyName: string -> string
+    abstract getPropertyValue: propertyName: string -> string
+    abstract item: index: float -> string
+    abstract removeProperty: propertyName: string -> string
+    abstract setProperty: propertyName: string * value: string * ?priority: string -> unit
+
+type [<AllowNullLiteral>] CSSStyleDeclarationType =
+    abstract prototype: CSSStyleDeclaration with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSStyleDeclaration
+
+type [<AllowNullLiteral>] CSSStyleRule =
+    inherit CSSRule
+    abstract readOnly: bool with get, set
+    abstract selectorText: string with get, set
+    abstract style: CSSStyleDeclaration with get, set
+
+type [<AllowNullLiteral>] CSSStyleRuleType =
+    abstract prototype: CSSStyleRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSStyleRule
+
+type [<AllowNullLiteral>] CSSStyleSheet =
+    inherit StyleSheet
+    abstract cssRules: CSSRuleList with get, set
+    abstract cssText: string with get, set
+    abstract href: string with get, set
+    abstract id: string with get, set
+    abstract imports: StyleSheetList with get, set
+    abstract isAlternate: bool with get, set
+    abstract isPrefAlternate: bool with get, set
+    abstract ownerRule: CSSRule with get, set
+    abstract owningElement: Element with get, set
+    abstract pages: StyleSheetPageList with get, set
+    abstract readOnly: bool with get, set
+    abstract rules: CSSRuleList with get, set
+    abstract addImport: bstrURL: string * ?lIndex: float -> float
+    abstract addPageRule: bstrSelector: string * bstrStyle: string * ?lIndex: float -> float
+    abstract addRule: bstrSelector: string * ?bstrStyle: string * ?lIndex: float -> float
+    abstract deleteRule: ?index: float -> unit
+    abstract insertRule: rule: string * ?index: float -> float
+    abstract removeImport: lIndex: float -> unit
+    abstract removeRule: lIndex: float -> unit
+
+type [<AllowNullLiteral>] CSSStyleSheetType =
+    abstract prototype: CSSStyleSheet with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSStyleSheet
+
+type [<AllowNullLiteral>] CSSSupportsRule =
+    inherit CSSConditionRule
+
+type [<AllowNullLiteral>] CSSSupportsRuleType =
+    abstract prototype: CSSSupportsRule with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> CSSSupportsRule
+
+type [<AllowNullLiteral>] StyleMedia =
+    abstract ``type``: string with get, set
+    abstract matchMedium: mediaquery: string -> bool
+
+type [<AllowNullLiteral>] StyleMediaType =
+    abstract prototype: StyleMedia with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> StyleMedia
+
+type [<AllowNullLiteral>] StyleSheet =
+    abstract disabled: bool with get, set
+    abstract href: string with get, set
+    // TODO
+    // abstract media: MediaList with get, set
+    abstract ownerNode: Node with get, set
+    abstract parentStyleSheet: StyleSheet with get, set
+    abstract title: string with get, set
+    abstract ``type``: string with get, set
+
+type [<AllowNullLiteral>] StyleSheetType =
+    abstract prototype: StyleSheet with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> StyleSheet
+
+type [<AllowNullLiteral>] StyleSheetList =
+    abstract length: float with get, set
+    [<Emit("$0[$1]{{=$2}}")>] abstract Item: index: int -> StyleSheet with get, set
+    abstract item: ?index: float -> StyleSheet
+
+type [<AllowNullLiteral>] StyleSheetListType =
+    abstract prototype: StyleSheetList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> StyleSheetList
+
+type [<AllowNullLiteral>] StyleSheetPageList =
+    abstract length: float with get, set
+    [<Emit("$0[$1]{{=$2}}")>] abstract Item: index: int -> CSSPageRule with get, set
+    abstract item: index: float -> CSSPageRule
+
+type [<AllowNullLiteral>] StyleSheetPageListType =
+    abstract prototype: StyleSheetPageList with get, set
+    [<Emit("new $0($1...)")>] abstract Create: unit -> StyleSheetPageList

--- a/src/Dom/Browser.Dom.fsproj
+++ b/src/Dom/Browser.Dom.fsproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\Event\Browser.Event.fsproj" />
     <ProjectReference Include="..\WebStorage\Browser.WebStorage.fsproj" />
     <ProjectReference Include="..\Blob\Browser.Blob.fsproj" />
+    <ProjectReference Include="..\Performance\Browser.Performance.fsproj" />
   </ItemGroup>
   <!-- This package doesn't contain actual code
        so we don't need to add the sources -->


### PR DESCRIPTION
@alfonsogarciacaro 

This PR is adding back SVG and CSS bindings.

I tried several things:

1. I wanted to use [dom.generated.d.ts](https://github.com/Microsoft/TypeScript/blob/master/src/lib/dom.generated.d.ts) from TypeScript repo but their `d.ts` and our binding is not matching easily. So I decided to port the API back from `Fable.Import.Browser`
2. I tried to create `Fable.Browser.CSS` and `Fable.Browser.SVG` but I don't think it's possible. The problem is that they `Fable.Browser.CSS`, `Fable.Browser.SVG` and `Fable.Browser.Dom` are creating a circular dependency tree. They all need each other to define part of their API. 

So in the end, I decided to add everything to `Fable.Browser.Dom` and use `// ## [Name of the section]` as you did for some part of the API.


