### PR TITLE
[WIP] Add Navigator package

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -15,6 +15,9 @@ let packages =
       "XMLHttpRequest"
       "Svg"
       "Css"
+      "Worker"
+      "Geolocation"
+      "Navigator"
     ]
 
 let ignoreCaseEquals (str1: string) (str2: string) =

--- a/README.md
+++ b/README.md
@@ -12,5 +12,10 @@ Fable bindings for [Browser Web APIs](https://developer.mozilla.org/docs/Web/API
 |[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.WebSocket.svg)](https://www.nuget.org/packages/Fable.Browser.WebSocket)|[Fable.Browser.WebSocket](src/WebSocket)|Bindings for the browser WebSocket API|
 |[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.WebStorage.svg)](https://www.nuget.org/packages/Fable.Browser.WebStorage)|[Fable.Browser.WebStorage](src/WebStorage)|Bindings for the Web Storage API|
 |[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.XMLHttpRequest.svg)](https://www.nuget.org/packages/Fable.Browser.XMLHttpRequest)|[Fable.Browser.XMLHttpRequest](src/XMLHttpRequest)|Bindings for the browser XMLHttpRequest API|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Svg.svg)](https://www.nuget.org/packages/Fable.Browser.Svg)|[Fable.Browser.Svg](src/Svg)|Bindings for the browser Svg API|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Css.svg)](https://www.nuget.org/packages/Fable.Browser.Css)|[Fable.Browser.Css](src/Css)|Bindings for the browser Css API|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Worker.svg)](https://www.nuget.org/packages/Fable.Browser.Worker)|[Fable.Browser.Worker](src/Worker)|Bindings for the browser Worker API|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Geolocation.svg)](https://www.nuget.org/packages/Fable.Browser.Geolocation)|[Fable.Browser.Geolocation](src/Geolocation)|Bindings for the browser Geolocation API|
+|[![Nuget Package](https://img.shields.io/nuget/v/Fable.Browser.Navigator.svg)](https://www.nuget.org/packages/Fable.Browser.Navigator)|[Fable.Browser.Navigator](src/Navigator)|Bindings for the browser Navigator API|
 
 - Publish: `npm run build Publish`

--- a/src/Geolocation/Browser.Geolocation.fs
+++ b/src/Geolocation/Browser.Geolocation.fs
@@ -1,0 +1,43 @@
+namespace Browser.Types
+
+open System
+open Fable.Core
+
+type Coordinates =
+    /// Returns a double representing the position's latitude in decimal degrees.
+    abstract latitude: float
+    /// Returns a double representing the position's longitude in decimal degrees.
+    abstract longitude: float
+    /// Returns a double representing the position's altitude in meters, relative to sea level. This value can be null if the implementation cannot provide the data.
+    abstract altitude: float option
+    /// Returns a double representing the accuracy of the latitude and longitude properties, expressed in meters.
+    abstract accuracy: float
+    /// Returns a double representing the accuracy of the altitude expressed in meters. This value can be null.
+    abstract altitudeAccuracy: float option
+    /// Returns a double representing the direction in which the device is traveling. This value, specified in degrees, indicates how far off from heading true north the device is. 0 degrees represents true north, and the direction is determined clockwise (which means that east is 90 degrees and west is 270 degrees). If speed is 0, heading is NaN. If the device is unable to provide heading information, this value is null.
+    abstract heading: float option
+    /// Returns a double representing the velocity of the device in meters per second. This value can be null.
+    abstract speed: float option
+
+type Position =
+    abstract coords: Coordinates
+    abstract timestamp: float
+
+type PositionErrorCode =
+    | PERMISSION_DENIED = 1
+    | POSITION_UNAVAILABLE = 2
+    | TIMEOUT = 3
+
+type PositionError =
+    abstract code: PositionErrorCode
+    abstract message: string
+
+type PositionOptions =
+    abstract enableHighAccuracy: bool option with get, set
+    abstract timeout: int option with get, set
+    abstract maximumAge: int option with get, set
+
+type Geolocation =
+    abstract clearWatch: watchId: float -> unit
+    abstract getCurrentPosition: successCallback: (Position->unit) * ?errorCallback: (PositionError->unit) * ?options: PositionOptions -> unit
+    abstract watchPosition: successCallback: (Position->unit) * ?errorCallback: (PositionError->unit) * ?options: PositionOptions -> float

--- a/src/Geolocation/Browser.Geolocation.fsproj
+++ b/src/Geolocation/Browser.Geolocation.fsproj
@@ -1,21 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Fable.Browser.Navigator</PackageId>
+    <PackageId>Fable.Browser.Geolocation</PackageId>
     <Version>0.0.0</Version>
     <PackageVersion>0.0.0</PackageVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Browser.Navigator.fs" />
+    <Compile Include="Browser.Geolocation.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="3.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Geolocation\Browser.Geolocation.fsproj" />
-    <ProjectReference Include="..\Worker\Browser.Worker.fsproj" />
   </ItemGroup>
   <!-- This package doesn't contain actual code
        so we don't need to add the sources -->

--- a/src/Geolocation/Browser.Geolocation.fsproj
+++ b/src/Geolocation/Browser.Geolocation.fsproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Fable.Browser.Geolocation</PackageId>
-    <Version>0.0.0</Version>
-    <PackageVersion>0.0.0</PackageVersion>
+    <Version>1.0.0</Version>
+    <PackageVersion>1.0.0-beta-001</PackageVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Geolocation/README.md
+++ b/src/Geolocation/README.md
@@ -1,0 +1,3 @@
+# Browser.Geolocation
+
+Includes bindings for the browser [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation).

--- a/src/Geolocation/RELEASE_NOTES.md
+++ b/src/Geolocation/RELEASE_NOTES.md
@@ -1,0 +1,3 @@
+### 1.0.0-beta-001
+
+* First release

--- a/src/Navigator/Browser.Navigator.fs
+++ b/src/Navigator/Browser.Navigator.fs
@@ -18,6 +18,11 @@ and Plugin =
     abstract item: index: int -> MimeType
     abstract namedItem: ``type``: string -> MimeType
 
+type ShareData =
+    abstract url: string with get, set
+    abstract text: string with get, set
+    abstract title: string with get, set
+
 type NavigatorID =
     abstract appName: string
     abstract appVersion: string
@@ -34,42 +39,43 @@ type NavigatorOnLine =
 type Navigator =
     inherit NavigatorID
     inherit NavigatorOnLine
-    // abstract activeVRDisplays
+    // TODO: abstract activeVRDisplays
     abstract appCodeName: string
     abstract appMinorVersion: string
-    // abstract battery
-    // abstract connection
+    // abstract battery // Deprecated
+    // TODO: abstract connection
     abstract cookieEnabled: bool
-    // abstract geolocation
+    abstract geolocation: Geolocation option
     abstract hardwareConcurrency: int
-    // abstract keyboard
+    // TODO: abstract keyboard
     abstract cpuClass: string
-    abstract language: string
-    abstract languages: string[]
-    // abstract locks
-    // abstract mediaCapabilities
+    abstract language: string option
+    abstract languages: string[] option
+    // TODO: abstract locks
+    // TODO: abstract mediaCapabilities
     abstract maxTouchPoints: int
-    abstract mimeTypes: MimeType[]
+    abstract mimeTypes: MimeType[] option
     abstract oscpu: string
-    // abstract permissions: Permissions
+    // TODO: abstract permissions: Permissions
     // abstract platform: string // Not reliable
-    abstract plugins: Plugin[]
-    // abstract serviceWorker: ServiceWorkerContainer
-    // abstract storage: StorageManager
+    abstract plugins: Plugin[] option
+    abstract serviceWorker: ServiceWorkerContainer option
+    // TODO: abstract storage: StorageManager
     abstract userAgent: string
     abstract webdriver: bool
 
 // ## Methods
 
     abstract canShare: unit -> bool
-    // abstract getVRDisplays()
-    // abstract getUserMedia()
-    // abstract sendBeacon()
-    // abstract registerProtocolHandler()
-    // abstract requestMediaKeySystemAccess()
-    // abstract sendBeacon()
-    // abstract share()
-    // abstract vibrate()
+    // TODO: abstract getVRDisplays()
+    // TODO: abstract getUserMedia()
+    // TODO: abstract registerProtocolHandler()
+    // TODO: abstract requestMediaKeySystemAccess()
+    // TODO: abstract sendBeacon()
+    abstract share: ShareData -> JS.Promise<unit>
+    /// Pulses the vibration hardware on the device, if such hardware exists. If the device doesn't support vibration, this method has no effect. If a vibration pattern is already in progress when this method is called, the previous pattern is halted and the new one begins instead.
+    /// - pattern: Provides a pattern of vibration and pause intervals. Each value indicates a number of milliseconds to vibrate or pause, in alternation. You may provide either a single value (to vibrate once for that many milliseconds) or an array of values to alternately vibrate, pause, then vibrate again. See Vibration API for details.
+    abstract vibrate: pattern: obj -> bool
 
 namespace Browser
 

--- a/src/Navigator/Browser.Navigator.fs
+++ b/src/Navigator/Browser.Navigator.fs
@@ -1,0 +1,81 @@
+namespace Browser.Types
+
+open System
+open Fable.Core
+
+type MimeType =
+    abstract description: string
+    abstract enabledPlugin: Plugin
+    abstract suffixes: string
+    abstract ``type``: string
+
+and Plugin =
+    abstract description: string
+    abstract filename: string
+    abstract length: int
+    abstract name: string
+    abstract version: string
+    abstract item: index: int -> MimeType
+    abstract namedItem: ``type``: string -> MimeType
+
+type NavigatorID =
+    abstract appName: string
+    abstract appVersion: string
+    abstract platform: string
+    abstract product: string
+    abstract productSub: string
+    abstract userAgent: string
+    abstract vendor: string
+    abstract vendorSub: string
+
+type NavigatorOnLine =
+    abstract onLine: bool
+
+type Navigator =
+    inherit NavigatorID
+    inherit NavigatorOnLine
+    // abstract activeVRDisplays
+    abstract appCodeName: string
+    abstract appMinorVersion: string
+    // abstract battery
+    // abstract connection
+    abstract cookieEnabled: bool
+    // abstract geolocation
+    abstract hardwareConcurrency: int
+    // abstract keyboard
+    abstract cpuClass: string
+    abstract language: string
+    abstract languages: string[]
+    // abstract locks
+    // abstract mediaCapabilities
+    abstract maxTouchPoints: int
+    abstract mimeTypes: MimeType[]
+    abstract oscpu: string
+    // abstract permissions: Permissions
+    // abstract platform: string // Not reliable
+    abstract plugins: Plugin[]
+    // abstract serviceWorker: ServiceWorkerContainer
+    // abstract storage: StorageManager
+    abstract userAgent: string
+    abstract webdriver: bool
+
+// ## Methods
+
+    abstract canShare: unit -> bool
+    // abstract getVRDisplays()
+    // abstract getUserMedia()
+    // abstract sendBeacon()
+    // abstract registerProtocolHandler()
+    // abstract requestMediaKeySystemAccess()
+    // abstract sendBeacon()
+    // abstract share()
+    // abstract vibrate()
+
+namespace Browser
+
+open Fable.Core
+open Browser.Types
+
+[<AutoOpen>]
+module Navigator =
+    let [<Global>] navigator: Navigator = jsNative

--- a/src/Navigator/Browser.Navigator.fsproj
+++ b/src/Navigator/Browser.Navigator.fsproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Fable.Browser.Navigator</PackageId>
-    <Version>0.0.0</Version>
-    <PackageVersion>0.0.0</PackageVersion>
+    <Version>1.0.0</Version>
+    <PackageVersion>1.0.0-beta-001</PackageVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Navigator/Browser.Navigator.fsproj
+++ b/src/Navigator/Browser.Navigator.fsproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>Fable.Browser.Css</PackageId>
+    <Version>1.0.0</Version>
+    <PackageVersion>1.0.0-beta-001</PackageVersion>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Browser.Navigator.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Fable.Core" Version="3.0.0" />
+  </ItemGroup>
+  <!-- This package doesn't contain actual code
+       so we don't need to add the sources -->
+  <!-- <ItemGroup>
+    <Content Include="*.fsproj; *.fs" PackagePath="fable\" />
+  </ItemGroup> -->
+</Project>

--- a/src/Navigator/README.md
+++ b/src/Navigator/README.md
@@ -1,0 +1,3 @@
+# Browser.Navigator
+
+Includes bindings for the browser [Navigator object](https://developer.mozilla.org/en-US/docs/Web/API/Navigator).

--- a/src/Navigator/RELEASE_NOTES.md
+++ b/src/Navigator/RELEASE_NOTES.md
@@ -1,0 +1,3 @@
+### 1.0.0-beta-001
+
+* First release

--- a/src/Worker/Browser.Worker.fs
+++ b/src/Worker/Browser.Worker.fs
@@ -1,0 +1,82 @@
+namespace Browser.Types
+
+open System
+open Fable.Core
+
+type AbstractWorker =
+    abstract onerror: (ErrorEvent -> unit) with get, set
+
+type Worker =
+    inherit EventTarget
+    inherit AbstractWorker
+    abstract onmessage: (MessageEvent -> unit) with get, set
+    abstract postMessage: message: obj * ?transfer: obj -> unit
+    abstract terminate: unit -> unit
+
+[<StringEnum>]
+type WorkerType =
+    | Classic
+    | Module
+
+[<StringEnum>]
+type WorkerCredentials =
+    | Omit
+    | [<CompiledName("same-origin")>] SameOrigin
+    | Include
+
+type WorkerOptions =
+    /// A DOMString specifying the type of worker to create. The value can be classic or module. If not specified, the default used is classic.
+    abstract ``type``: WorkerType with get, set
+    /// A DOMString specifying the type of credentials to use for the worker. The value can be omit, same-origin, or include. If not specified, or if type is classic, the default used is omit (no credentials required).
+    abstract credentials: WorkerCredentials with get, set
+    /// A DOMString specifying an identifying name for the DedicatedWorkerGlobalScope representing the scope of the worker, which is mainly useful for debugging purposes.
+    abstract name: string with get, set
+
+type WorkerConstructor =
+    [<Emit("new $0($1...)")>] abstract Create: url: string * ?options: WorkerOptions -> Worker
+
+[<StringEnum; RequireQualifiedAccess>]
+type ServiceWorkerState =
+    | Installing
+    | Installed
+    | Activating
+    | Activated
+    | Redundant
+
+type ServiceWorker =
+    inherit Worker
+    abstract scriptURL: string
+    abstract state: ServiceWorkerState
+    abstract onstatechange: (Event -> unit) option with get, set
+
+type ServiceWorkerRegistration =
+    abstract scope: string
+    abstract installing: ServiceWorker option
+    abstract waiting: ServiceWorker option
+    abstract active: ServiceWorker option
+    // TODO abstract navigationPreload
+    // TODO: abstract pushManager: PushManager
+    abstract onupdatefound: (Event -> unit) option with get, set
+    // TODO: abstract getNotifications: ?options: ServiceWorkerNotificationOptions -> JS.Promise<Notification[]>
+    // TODO: abstract showNotifications()
+    abstract update: unit -> JS.Promise<ServiceWorkerRegistration>
+    abstract unregister: unit -> JS.Promise<bool>
+
+type ServiceWorkerRegistrationOptions =
+    /// A USVString representing a URL that defines a service worker's registration scope; that is, what range of URLs a service worker can control. This is usually a relative URL. It is relative to the base URL of the application. By default, the scope value for a service worker registration is set to the directory where the service worker script is located.
+    abstract scope: string with get, set
+
+type ServiceWorkerContainer =
+    abstract controller: ServiceWorker option
+    abstract ready: JS.Promise<ServiceWorkerRegistration>
+    abstract oncontrollerchange: (Event -> unit) with get, set
+    abstract onerror: (Event -> unit) with get, set
+    abstract onmessage: (Event -> unit) with get, set
+    abstract register: url: string * ?options: ServiceWorkerRegistrationOptions -> JS.Promise<ServiceWorkerRegistration>
+    abstract getRegistration: ?scope: string -> JS.Promise<ServiceWorkerRegistration>
+    abstract getRegistrations: unit -> JS.Promise<ServiceWorkerRegistration[]>
+    abstract startMessages: unit -> unit
+
+[<AutoOpen>]
+module Event =
+    let [<Global>] Worker: WorkerConstructor = jsNative

--- a/src/Worker/Browser.Worker.fsproj
+++ b/src/Worker/Browser.Worker.fsproj
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Fable.Browser.Navigator</PackageId>
+    <PackageId>Fable.Browser.Worker</PackageId>
     <Version>0.0.0</Version>
     <PackageVersion>0.0.0</PackageVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Browser.Navigator.fs" />
+    <Compile Include="Browser.Worker.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Geolocation\Browser.Geolocation.fsproj" />
-    <ProjectReference Include="..\Worker\Browser.Worker.fsproj" />
+    <ProjectReference Include="..\Event\Browser.Event.fsproj" />
   </ItemGroup>
   <!-- This package doesn't contain actual code
        so we don't need to add the sources -->

--- a/src/Worker/Browser.Worker.fsproj
+++ b/src/Worker/Browser.Worker.fsproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Fable.Browser.Worker</PackageId>
-    <Version>0.0.0</Version>
-    <PackageVersion>0.0.0</PackageVersion>
+    <Version>1.0.0</Version>
+    <PackageVersion>1.0.0-beta-001</PackageVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Worker/README.md
+++ b/src/Worker/README.md
@@ -1,0 +1,3 @@
+# Browser.Worker
+
+Includes bindings for the browser [Web Workers API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).

--- a/src/Worker/RELEASE_NOTES.md
+++ b/src/Worker/RELEASE_NOTES.md
@@ -1,0 +1,3 @@
+### 1.0.0-beta-001
+
+* First release


### PR DESCRIPTION
Fixes #10 (cc @forki) #15 

As most of the properties in the navigator object are experimental I opted for marking them as `option` so users need to check if they actually exist or not. Please note that (to avoid the dependency with the Browser.Dom package) `navigator` is exposed as a global value instead of a `window` property.

I left several `TODO`s. It'd be great if someone could review and fill the gaps using MDN documentation and the [old bindings](https://github.com/fable-compiler/fable-import/blob/master/Browser/Fable.Import.Browser.fs).

Beta versions of the new packages have already been pushed.