### PR TITLE
Move FormData to Blob package

### DIFF
--- a/src/Blob/Browser.Blob.fs
+++ b/src/Blob/Browser.Blob.fs
@@ -22,6 +22,22 @@ type [<AllowNullLiteral>] Blob =
 type [<AllowNullLiteral>] BlobType =
     [<Emit("new $0($1...)")>] abstract Create: ?blobParts: obj[] * ?options: BlobPropertyBag -> Blob
 
+type [<AllowNullLiteral>] FormData =
+    abstract append: name: string * value: string -> unit
+    abstract append: name: string * value: Blob * ?filename: string -> unit
+    abstract delete: name: string -> unit
+    abstract entries: unit -> (string * obj) seq
+    abstract get: name: string -> obj
+    abstract getAll: name: string -> obj[]
+    abstract has: name: string -> bool
+    abstract keys: unit -> string seq
+    abstract set: name: string * value: string -> unit
+    abstract set: name: string * value: Blob * ?filename: string -> unit
+    abstract values: unit -> obj seq
+
+type [<AllowNullLiteral>] FormDataType =
+    [<Emit("new $0($1...)")>] abstract Create: unit -> FormData
+
 namespace Browser
 
 open Fable.Core
@@ -30,3 +46,4 @@ open Browser.Types
 [<AutoOpen>]
 module Blob =
     let [<Global>] Blob: BlobType = jsNative
+    let [<Global>] FormData: FormDataType = jsNative

--- a/src/Dom/Browser.Dom.Ext.fs
+++ b/src/Dom/Browser.Dom.Ext.fs
@@ -1,0 +1,9 @@
+[<AutoOpen>]
+module Browser.DomExtensions
+
+open Fable.Core
+open Browser.Types
+
+type FormDataType with
+    [<Emit("new $0($1...)")>]
+    member __.Create(form: HTMLFormElement): FormData = jsNative

--- a/src/Dom/Browser.Dom.fsproj
+++ b/src/Dom/Browser.Dom.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Browser.File.fs" />
     <Compile Include="Browser.History.fs" />
     <Compile Include="Browser.Dom.fs" />
+    <Compile Include="Browser.Dom.Ext.fs" />    
     <Compile Include="Browser.Dom.Api.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/XMLHttpRequest/Browser.XMLHttpRequest.fs
+++ b/src/XMLHttpRequest/Browser.XMLHttpRequest.fs
@@ -41,20 +41,6 @@ type [<AllowNullLiteral>] XMLHttpRequest =
 type [<AllowNullLiteral>] XMLHttpRequestType =
     [<Emit("new $0($1...)")>] abstract Create: unit -> XMLHttpRequest
 
-type [<AllowNullLiteral>] FormData =
-    abstract append: name: string * value: obj * ?filename: string -> unit
-    abstract delete: name: string -> unit
-    abstract entries: unit -> (string * obj) seq
-    abstract get: name: string -> obj
-    abstract getAll: name: string -> obj[]
-    abstract has: name: string -> bool
-    abstract keys: unit -> string seq
-    abstract set: name: string * value: obj * ?filename: string -> unit
-    abstract values: unit -> obj seq
-
-type [<AllowNullLiteral>] FormDataType =
-    [<Emit("new $0($1...)")>] abstract Create: ?form: HTMLFormElement -> FormData
-
 namespace Browser
 
 open Fable.Core
@@ -63,4 +49,3 @@ open Browser.Types
 [<AutoOpen>]
 module XMLHttpRequest =
     let [<Global>] XMLHttpRequest: XMLHttpRequestType = jsNative
-    let [<Global>] FormData: FormDataType = jsNative

--- a/src/XMLHttpRequest/Browser.XMLHttpRequest.fsproj
+++ b/src/XMLHttpRequest/Browser.XMLHttpRequest.fsproj
@@ -14,7 +14,8 @@
     <PackageReference Include="Fable.Core" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Dom\Browser.Dom.fsproj" />
+    <ProjectReference Include="..\Blob\Browser.Blob.fsproj" />
+    <ProjectReference Include="..\Event\Browser.Event.fsproj" />
   </ItemGroup>
   <!-- This package doesn't contain actual code
        so we don't need to add the sources -->


### PR DESCRIPTION
Related to https://github.com/fable-compiler/fable-fetch/issues/4

@MangelMaxime I moved `FormData` to the Blob package, could you please review? A couple of other changes:

- I added overloads for `append` and `set` for string or Blob, but not sure what do with the retrieving methods like `getAll`, `entries` or `values`.
- I've added the constructor overload accepting `HTMLFormElement` as an extension in the Dom package.