### PR TITLE
Fix typo in RTCRtpSender and add missing getStats method in RTCPeerConnection

### DIFF
--- a/src/WebRTC/Browser.WebRTC.fs
+++ b/src/WebRTC/Browser.WebRTC.fs
@@ -845,6 +845,7 @@ type RTCPeerConnection =
 
     abstract removeTrack: sender:RTCRtpSender -> unit
 
+    abstract getStats: unit -> JS.Promise<RTCStatsReport>
     abstract addTransceiver: track:MediaStreamTrack * ?init: RTCRtpTransceiverInit -> RTCRtpTransceiver
     abstract addTransceiver: trackKind:TrackKind -> RTCRtpTransceiver
     abstract ontrack: (RTCTrackEvent->unit) with get,set

--- a/src/WebRTC/Browser.WebRTC.fs
+++ b/src/WebRTC/Browser.WebRTC.fs
@@ -661,7 +661,7 @@ type RTCRtpSender =
 
     [<Emit("$0.setStreams($1...)")>]
     abstract setStreams: [<ParamArray>] streams:MediaStream [] -> unit
-    abstract getStates: unit -> JS.Promise<RTCStatsReport>
+    abstract getStats: unit -> JS.Promise<RTCStatsReport>
 
 type RTCRtpSenderType =
     [<Emit("RTCRtpSender.getCapabilities($1)")>]

--- a/src/WebRTC/Browser.WebRTC.fsproj
+++ b/src/WebRTC/Browser.WebRTC.fsproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Fable.Browser.WebRTC</PackageId>
-    <Version>1.0.0</Version>
-    <PackageVersion>1.0.0-beta-001</PackageVersion>
+    <Version>1.0.1</Version>
+    <PackageVersion>1.0.1-beta-001</PackageVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/WebRTC/RELEASE_NOTES.md
+++ b/src/WebRTC/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 1.0.1
+
+* Fix `RTCRtpReceiver.getStates` should be a `RTCRtpReceiver.getStats`
+
 ### 1.0.0
 
 * First stable release


### PR DESCRIPTION
`getStates` -> `getStats`.
And add missing [`getStats`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats) method in RTCPeerConnection. 
@alfonsogarciacaro if everything is okay I could push a NuGet.