### PR TITLE
RTCIceCandidateStats.protocol as RTCIceProtocol instead of string.

### DIFF
--- a/src/WebRTC/Browser.WebRTC.fs
+++ b/src/WebRTC/Browser.WebRTC.fs
@@ -79,12 +79,6 @@ type RTCDataChannelEvent =
     inherit Event
     abstract channel: RTCDataChannel
 
-
-
-
-
-
-
 [<StringEnum>]
 type RTCIceCredentialType =
     | Password
@@ -109,10 +103,6 @@ type RTCIceTransportComponent =
 type RTCIceComponent =
     | [<CompiledName("rtp")>] RTP
     | [<CompiledName("rtcp")>] RTCP
-
-
-
-
 
 type RTCOfferAnswerOptions =
     abstract voiceActivityDetection: bool option with get, set
@@ -582,7 +572,7 @@ type RTCIceCandidateStats =
     abstract networkType: RTCNetworkType
     abstract ip: string
     abstract port: int64
-    abstract protocol: string
+    abstract protocol: RTCIceProtocol
     abstract candidateType: RTCIceCandidateType
     abstract priority: int64
     abstract url: string

--- a/src/WebRTC/Browser.WebRTC.fsproj
+++ b/src/WebRTC/Browser.WebRTC.fsproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Fable.Browser.WebRTC</PackageId>
-    <Version>1.0.1</Version>
-    <PackageVersion>1.0.1</PackageVersion>
+    <Version>1.0.2</Version>
+    <PackageVersion>1.0.2</PackageVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/WebRTC/RELEASE_NOTES.md
+++ b/src/WebRTC/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 1.0.2
+
+* `RTCIceCandidateStats.protocol` accepts only `udp` or `tcp` so it could be specify as `RTCIceProtocol` instead of string.
+
 ### 1.0.1
 
 * Fix `RTCRtpReceiver.getStates` should be a `RTCRtpReceiver.getStats`

--- a/src/WebRTC/RELEASE_NOTES.md
+++ b/src/WebRTC/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ### 1.0.2
 
-* `RTCIceCandidateStats.protocol` accepts only `udp` or `tcp` so it could be specify as `RTCIceProtocol` instead of string.
+* `RTCIceCandidateStats.protocol` accepts only `udp` or `tcp` so it could be specified as `RTCIceProtocol` instead of a string.
 
 ### 1.0.1
 


### PR DESCRIPTION
`RTCIceCandidateStats.protocol` accepts only `udp` or `tcp` so it could be specified as `RTCIceProtocol` instead of a string.

[Documentation](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidateStats/protocol)

CC: @MangelMaxime 