### PR TITLE
Make explicit overloads for (add | remove)EventListener

### DIFF
--- a/src/Event/Browser.Event.fs
+++ b/src/Event/Browser.Event.fs
@@ -43,12 +43,12 @@ type [<AllowNullLiteral>] RemoveEventListenerOptions =
 
 type [<AllowNullLiteral>] EventTarget =
     abstract addEventListener: ``type``: string * listener: (Event->unit) -> unit
-    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
-    abstract addEventListener: ``type``: string * listener: (Event->unit) * ?options: AddEventListenerOptions -> unit
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * useCapture: bool -> unit
+    abstract addEventListener: ``type``: string * listener: (Event->unit) * options: AddEventListenerOptions -> unit
     abstract dispatchEvent: evt: Event -> bool
     abstract removeEventListener: ``type``: string * listener: (Event->unit) -> unit
-    abstract removeEventListener: ``type``: string * listener: (Event->unit) * ?useCapture: bool -> unit
-    abstract removeEventListener: ``type``: string * listener: (Event->unit) * ?options: RemoveEventListenerOptions -> unit
+    abstract removeEventListener: ``type``: string * listener: (Event->unit) * useCapture: bool -> unit
+    abstract removeEventListener: ``type``: string * listener: (Event->unit) * options: RemoveEventListenerOptions -> unit
 
 type [<AllowNullLiteral>] EventTargetType =
     [<Emit("new $0($1...)")>] abstract Create: ``type``: string * ?eventInitDict: EventInit -> Event


### PR DESCRIPTION
Overloads don't play well with optional parameters and one should use either. In this case, since we have overloads, it is sufficient to make the other parameters non-optional so that Fable know which overload to fix. Fixes #43 and any other project using one of these functions with an optional parameter

cc @MangelMaxime 