### PR TITLE
#52 add missing URI functions

### DIFF
--- a/src/Dom/Browser.Dom.fs
+++ b/src/Dom/Browser.Dom.fs
@@ -805,6 +805,12 @@ type [<AllowNullLiteral>] WindowBase64 =
     abstract atob: encodedString: string -> string
     abstract btoa: rawString: string -> string
 
+type [<AllowNullLiteral>] WindowURI =
+    abstract decodeURI: encodedURI: string -> string
+    abstract encodeURI: uri: string -> string
+    abstract decodeURIComponent: encodedUri: string -> string
+    abstract encodeURIComponent: str: string -> string
+
 type [<AllowNullLiteral>] Window =
     inherit EventTarget
     inherit WindowTimers
@@ -812,6 +818,7 @@ type [<AllowNullLiteral>] Window =
     inherit WindowLocalStorage
     inherit GlobalEventHandlers
     inherit WindowBase64
+    inherit WindowURI
     // TODO
     // abstract performance: Performance with get, set
     // abstract clientInformation: Navigator with get, set

--- a/src/Dom/RELEASE_NOTES.md
+++ b/src/Dom/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 2.2.0
+
+* Fix #52: Add decodeURI, encodeURI, decodeURIComponent, encodeURIComponent to a `window` @MNie
+
 ### 2.1.2
 
 * Fix #48: FSharp.Core dependency @forki


### PR DESCRIPTION
Fixes: #52 

PR adds:
- [decodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent),
- [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent),
- [decodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI),
- [encodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)