### PR TITLE
Fix #89: Add `orientation` to `window.screen`

### DIFF
--- a/src/Dom/Browser.Dom.fs
+++ b/src/Dom/Browser.Dom.fs
@@ -808,6 +808,32 @@ type [<AllowNullLiteral>] TreeWalkerType =
 type [<AllowNullLiteral>] BarProp =
     abstract visible: bool with get, set
 
+[<StringEnum; RequireQualifiedAccess>]
+type ScreenOrientationType =
+    | [<CompiledName("portrait-primary")>] PortraitPrimary
+    | [<CompiledName("portrait-secondary")>] PortraitSecondary
+    | [<CompiledName("landscape-primary")>] LandscapePrimary
+    | [<CompiledName("landscape-secondary")>] LandscapeSecondary
+
+[<StringEnum; RequireQualifiedAccess>]
+type OrientationLockType =
+    | [<CompiledName("any")>] Any
+    | [<CompiledName("natural")>] Natural
+    | [<CompiledName("landscape")>] Landscape
+    | [<CompiledName("portrait")>] Portrait
+    | [<CompiledName("portrait-primary")>] PortraitPrimary
+    | [<CompiledName("portrait-secondary")>] PortraitSecondary
+    | [<CompiledName("landscape-primary")>] LandscapePrimary
+    | [<CompiledName("landscape-secondary")>] LandscapeSecondary
+
+type [<AllowNullLiteral>] ScreenOrientation =
+    inherit EventTarget
+    abstract ``type``: ScreenOrientationType
+    abstract angle: int
+    abstract onchange: (Event -> unit) with get, set
+    abstract lock: OrientationLockType -> JS.Promise<unit>
+    abstract unlock: unit -> unit
+
 type [<AllowNullLiteral>] Screen =
     inherit EventTarget
     abstract availHeight: float with get, set
@@ -824,6 +850,7 @@ type [<AllowNullLiteral>] Screen =
     abstract systemXDPI: float with get, set
     abstract systemYDPI: float with get, set
     abstract width: float with get, set
+    abstract orientation: ScreenOrientation with get, set
 
 type [<AllowNullLiteral>] Location =
     abstract hash: string with get, set

--- a/src/Dom/Browser.Dom.fsproj
+++ b/src/Dom/Browser.Dom.fsproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Fable.Browser.Dom</PackageId>
-    <Version>2.7.0</Version>
-    <PackageVersion>2.7.0</PackageVersion>
+    <Version>2.8.0</Version>
+    <PackageVersion>2.8.0</PackageVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Dom/RELEASE_NOTES.md
+++ b/src/Dom/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ### 2.8.0
 
-* Fix #89: Add `orientation` to `window.screen`
+* Fix #89: Add `orientation` to `window.screen` @sumeetdas
 
 ### 2.7.0
 

--- a/src/Dom/RELEASE_NOTES.md
+++ b/src/Dom/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 2.8.0
+
+* Fix #89: Add `orientation` to `window.screen`
+
 ### 2.7.0
 
 * Fix #86: Add `nextElementSibling` and `previousElementSibling` methods


### PR DESCRIPTION
This PR will add [`orientation`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation) to `window.screen` object.