### PR TITLE
Browser.Dom: add support for Element.toggleAttribute

### DIFF
--- a/src/Dom/Browser.Dom.fs
+++ b/src/Dom/Browser.Dom.fs
@@ -476,6 +476,8 @@ type [<AllowNullLiteral>] Element =
     abstract setAttributeNS: namespaceURI: string * qualifiedName: string * value: string -> unit
     abstract setAttributeNode: newAttr: Attr -> Attr
     abstract setAttributeNodeNS: newAttr: Attr -> Attr
+    [<Emit("$0.toggleAttribute($1, $2 ?? undefined)")>]
+    abstract toggleAttribute: name: string * force: bool option -> bool
     abstract setPointerCapture: pointerId: float -> unit
     abstract getElementsByClassName: classNames: string -> NodeListOf<Element>
     abstract matches: selector: string -> bool


### PR DESCRIPTION
This adds support for `Element.toggleAttribute`.
As I don't know much javascript tbh (thank you Fable❤), I am not sure whether the `??` operator is too 'modern' to use.