### PR TITLE
MediaRecorder.isTypeSupported

### DIFF
--- a/src/MediaRecorder/Browser.MediaRecorder.fs
+++ b/src/MediaRecorder/Browser.MediaRecorder.fs
@@ -53,6 +53,7 @@ type MediaRecorderOptions =
 
 type MediaRecorderType =
     [<Emit("new $0($1...)")>] abstract Create: stream: MediaStream * ?options: MediaRecorderOptions -> MediaRecorder
+    abstract isTypeSupported: mimeType: string -> bool
 
 namespace Browser
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/isTypeSupported