### PR TITLE
Expose imageSmoothingEnabled on CanvasRenderingContext2D

### DIFF
--- a/src/Dom/Browser.Dom.fs
+++ b/src/Dom/Browser.Dom.fs
@@ -2817,6 +2817,7 @@ type [<AllowNullLiteral; Global>] CanvasRenderingContext2D =
     abstract ellipse: x: float * y: float * radiusX: float * radiusY: float * rotation: float * startAngle: float * endAngle:float * ?anticlockwise: bool -> unit
     abstract isPointInStroke: x:float * y: float -> bool
     abstract isPointInStroke: path: string * x: float * y: float -> bool
+    abstract imageSmoothingEnabled: bool with get, set 
 
 type [<AllowNullLiteral>] CanvasRenderingContext2DType =
     [<Emit("new $0($1...)")>] abstract Create: unit -> CanvasRenderingContext2D

--- a/src/Dom/RELEASE_NOTES.md
+++ b/src/Dom/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+### 2.10.1
+* Add `CanvasRenderingContext2D.imageSmoothingEnabled`
 ### 2.10.0
 
 * Add Global attribute to global interfaces @chkn


### PR DESCRIPTION
I would like to expose https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled to the CanvasRenderingContext2D.

I am very new to fable and honestly not too sure how this should be done, found an old issue on https://github.com/fable-compiler/Fable/issues/644#issuecomment-271911365 and it worked to use the dynamic call as described there with
```
open Fable.Core.JsInterop
ctx?imageSmoothingEnabled <- false
```

The issue mentioned something about upgrading ```ts2fable```, so there are perhaps better way to expose this, but that was from 2017.

I tried to follow similar changes as in https://github.com/fable-compiler/fable-browser/commit/e091f8b20ee432b5dafee3459a8ac47d48d445da#diff-91d379c5b101345f00a814c5f4a2406e862cc022df4c4d6d9183c86e66aac8a5to add the parameter.