### PR TITLE
Remove unnecessary/broken .text field from File

### DIFF
--- a/src/Dom/Browser.File.fs
+++ b/src/Dom/Browser.File.fs
@@ -17,7 +17,6 @@ type [<AllowNullLiteral; Global>] File =
     inherit Blob
     abstract lastModified: float
     abstract name: string
-    abstract text: Promise<string>
 
 type [<AllowNullLiteral>] FileType =
     [<Emit("new $0($1...)")>] abstract Create: parts: obj[] * filename: string * ?properties: FilePropertyBag -> File


### PR DESCRIPTION
`File` inherits `Blob` which already has a `.text()` method. [MDN](https://developer.mozilla.org/en-US/docs/Web/API/File).
Also, the current abstract `text` field on `File` does not get compiled into a method call, but rather a field access.

