### PR TITLE
Add way to pass HTML form to FormData creation

### DIFF
--- a/src/Blob/Browser.Blob.fs
+++ b/src/Blob/Browser.Blob.fs
@@ -3,6 +3,7 @@ namespace Browser.Types
 open System
 open Fable.Core
 open Fable.Core.JS
+open Browser.Dom
 
 [<StringEnum; RequireQualifiedAccess>]
 type BlobEndings =
@@ -39,7 +40,7 @@ type [<AllowNullLiteral; Global>] FormData =
     abstract values: unit -> obj seq
 
 type [<AllowNullLiteral>] FormDataType =
-    [<Emit("new $0($1...)")>] abstract Create: unit -> FormData
+    [<Emit("new $0($1...)")>] abstract Create: ?form : HTMLFormElement -> FormData
 
 namespace Browser
 

--- a/src/Blob/Browser.Blob.fsproj
+++ b/src/Blob/Browser.Blob.fsproj
@@ -14,6 +14,9 @@
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="3.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Dom\Browser.Dom.fsproj" />
+  </ItemGroup>
   <!-- This package doesn't contain actual code
        so we don't need to add the sources -->
   <!-- <ItemGroup>


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData, the constructor should be able to take an optional `<form>`/`HTMLFormElement.