### PR TITLE
Change MediaRecorder properties from uint64 to uint32

### DIFF
--- a/src/MediaRecorder/Browser.MediaRecorder.fs
+++ b/src/MediaRecorder/Browser.MediaRecorder.fs
@@ -27,8 +27,8 @@ type [<Global>] MediaRecorder =
     abstract mimeType: string
     abstract state: MediaRecorderState
     abstract stream: MediaStream
-    abstract videoBitsPerSecond: uint64
-    abstract audioBitsPerSecond: uint64
+    abstract videoBitsPerSecond: uint32
+    abstract audioBitsPerSecond: uint32
 
     abstract pause: unit -> unit
     abstract requestData: unit -> unit
@@ -47,9 +47,9 @@ type [<Global>] MediaRecorder =
 
 type MediaRecorderOptions =
     abstract mimeType: string with get, set
-    abstract audioBitsPerSecond: uint64 with get, set
-    abstract videoBitsPerSecond: uint64 with get, set
-    abstract bitsPerSecond: uint64 with get, set
+    abstract audioBitsPerSecond: uint32 with get, set
+    abstract videoBitsPerSecond: uint32 with get, set
+    abstract bitsPerSecond: uint32 with get, set
 
 type MediaRecorderType =
     [<Emit("new $0($1...)")>] abstract Create: stream: MediaStream * ?options: MediaRecorderOptions -> MediaRecorder


### PR DESCRIPTION
Fixes #118.

`uint32` is used throughout `Browser.MediaStream`, so I decided to stick with unsigned.