### PR TITLE
Add optional parameter to MediaRecorder.start

### DIFF
--- a/src/MediaRecorder/Browser.MediaRecorder.fs
+++ b/src/MediaRecorder/Browser.MediaRecorder.fs
@@ -33,7 +33,7 @@ type [<Global>] MediaRecorder =
     abstract pause: unit -> unit
     abstract requestData: unit -> unit
     abstract resume: unit -> unit
-    abstract start: unit -> unit
+    abstract start: ?timesliceMilliseconds: float -> unit
     abstract stop: unit -> unit
 
     abstract isTypeSupported: string -> bool


### PR DESCRIPTION
Fixes https://github.com/fable-compiler/fable-browser/issues/120.