### PR TITLE
Add EventSource API support

### DIFF
--- a/Browser.sln
+++ b/Browser.sln
@@ -51,6 +51,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Browser.IntersectionObserve
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Browser.ResizeObserver", "src\ResizeObserver\Browser.ResizeObserver.fsproj", "{CFEB63B4-8CDC-4FD2-B0C5-4D09BE37D00B}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Browser.EventSource", "src\EventSource\Browser.EventSource.fsproj", "{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -337,6 +339,18 @@ Global
 		{CFEB63B4-8CDC-4FD2-B0C5-4D09BE37D00B}.Release|x64.Build.0 = Release|Any CPU
 		{CFEB63B4-8CDC-4FD2-B0C5-4D09BE37D00B}.Release|x86.ActiveCfg = Release|Any CPU
 		{CFEB63B4-8CDC-4FD2-B0C5-4D09BE37D00B}.Release|x86.Build.0 = Release|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Debug|x64.Build.0 = Debug|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Debug|x86.Build.0 = Debug|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Release|x64.Build.0 = Release|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -364,6 +378,7 @@ Global
 		{937E046F-818B-47E1-930F-3B0A0068D83B} = {D9506C1D-DF7A-4975-B4A9-80B2EF4ADA2E}
 		{B74AA790-1B29-448A-8D75-8399C6C86C71} = {D9506C1D-DF7A-4975-B4A9-80B2EF4ADA2E}
 		{CFEB63B4-8CDC-4FD2-B0C5-4D09BE37D00B} = {D9506C1D-DF7A-4975-B4A9-80B2EF4ADA2E}
+		{D79F73C5-8BE4-4D57-8CCD-28CC99B1A9A1} = {D9506C1D-DF7A-4975-B4A9-80B2EF4ADA2E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F62BBD2A-9074-44FF-8208-43DA064745DE}

--- a/build.fsx
+++ b/build.fsx
@@ -29,6 +29,7 @@ let packages =
       "IndexedDB"
       "IntersectionObserver"
       "ResizeObserver"
+      "EventSource"
     ]
 
 let ignoreCaseEquals (str1: string) (str2: string) =

--- a/src/EventSource/Browser.EventSource.fs
+++ b/src/EventSource/Browser.EventSource.fs
@@ -1,0 +1,50 @@
+﻿namespace rec Browser.Types
+
+open System
+open Fable.Core
+
+type EventSourceState =
+    | CONNECTING = 0
+    | OPEN = 1
+    | CLOSED = 2
+
+[<AllowNullLiteral; Global>]
+type EventSource =
+    inherit EventTarget
+    abstract readyState: EventSourceState
+    abstract url: string
+    abstract withCredentials: bool
+
+    abstract close: unit -> unit
+
+    abstract onerror: (Event -> unit) with get, set
+    abstract onmessage: (MessageEvent -> unit) with get, set
+    abstract onopen: (Event -> unit) with get, set
+
+    [<Emit("$0.addEventListener('error',$1...)")>]
+    abstract addEventListener_error: listener: (Event -> unit) * ?useCapture: bool -> unit
+
+    [<Emit("$0.addEventListener('message',$1...)")>]
+    abstract addEventListener_message: listener: (MessageEvent -> unit) * ?useCapture: bool -> unit
+
+    [<Emit("$0.addEventListener('open',$1...)")>]
+    abstract addEventListener_open: listener: (Event -> unit) * ?useCapture: bool -> unit
+
+[<AllowNullLiteral>]
+type EventSourceOptions =
+    abstract withCredentials: bool with get, set
+
+[<AllowNullLiteral>]
+type EventSourceType =
+    [<Emit("new $0($1...)")>]
+    abstract Create: url: string * ?options: EventSourceOptions -> EventSource
+
+namespace Browser
+
+open Fable.Core
+open Browser.Types
+
+[<AutoOpen>]
+module EventSource =
+    [<Global>]
+    let EventSource: EventSourceType = jsNative

--- a/src/EventSource/Browser.EventSource.fsproj
+++ b/src/EventSource/Browser.EventSource.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>Fable.Browser.EventSource</PackageId>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Tags>fable;fable-binding;fable-javascript</Tags>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Browser.EventSource.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Fable.Core" Version="3.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Event\Browser.Event.fsproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
As per issue #134 this PR adds [EventSource API](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) support to Fable.